### PR TITLE
v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export SENTRY_DSN=http://public:secret@example.com/project-id
 ```crystal
 # Or you can configure the client in the code (not recommended - keep your DSN secret!)
 Raven.configure do |config|
-  config.server = "http://public:secret@example.com/project-id"
+  config.dsn = "http://public:secret@example.com/project-id"
 end
 ```
 
@@ -96,7 +96,7 @@ variable, there are two other configuration settings for controlling Raven:
 # DSN can be configured as a config setting instead.
 # Place in config/initializers or similar.
 Raven.configure do |config|
-  config.server = "your_dsn"
+  config.dsn = "your_dsn"
 end
 ```
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 0.3.1-dev
+version: 0.4.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 0.3.0
+version: 0.3.1-dev
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/src/raven.cr
+++ b/src/raven.cr
@@ -1,4 +1,6 @@
 require "any_hash"
+
+require "./raven/mixins/*"
 require "./raven/*"
 
 class Exception

--- a/src/raven.cr
+++ b/src/raven.cr
@@ -1,11 +1,8 @@
 require "any_hash"
 
+require "./raven/ext/*"
 require "./raven/mixins/*"
 require "./raven/*"
-
-class Exception
-  any_json_property __raven_context
-end
 
 module Raven
   # `Raven.instance` delegators.
@@ -13,23 +10,25 @@ module Raven
     delegate :context, :logger, :configuration, :client,
       :report_status, :configure, :send_event, :capture,
       :last_event_id, :annotate_exception, :user_context,
-      :tags_context, :extra_context, :breadcrumbs, to: :instance
+      :tags_context, :extra_context, :breadcrumbs,
+      to: :instance
   end
 end
 
 module Raven
   extend Delegators
-  class_getter instance : Raven::Instance { Raven::Instance.new }
 
-  def self.sys_command(command)
-    result = `#{command} 2>&1`.strip rescue nil
-    return if result.nil? || result.empty? || !$?.success?
-    result
-  end
+  class_getter instance : Raven::Instance { Raven::Instance.new }
 
   macro sys_command_compiled(command)
     %result = {{ system("#{command.id} || true").stringify.strip }}
     return if %result.empty?
     %result
+  end
+
+  def self.sys_command(command)
+    result = `#{command} 2>&1`.strip rescue nil
+    return if result.nil? || result.empty? || !$?.success?
+    result
   end
 end

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -53,7 +53,6 @@ module Raven
         column = match["col"]?
         method = match["proc_method"]? || match["method"]?
       end
-      # pp match
       new(file, number.try(&.to_i), column.try(&.to_i), method)
     end
 

--- a/src/raven/breadcrumb.cr
+++ b/src/raven/breadcrumb.cr
@@ -22,11 +22,16 @@ module Raven
     # A timestamp representing when the breadcrumb occurred.
     property timestamp : Time
 
-    # The type of breadcrumb. The default type is `default` which indicates
+    # The type of breadcrumb. The default type is `:default` which indicates
     # no specific handling. Other types are currently:
-    # - `http` for HTTP requests and
-    # - `navigation` for navigation events.
+    # - `:http` for HTTP requests and
+    # - `:navigation` for navigation events.
     property type : Type?
+
+    # ditto
+    def type=(type : Symbol)
+      @type = Type.parse(type.to_s)
+    end
 
     # If a message is provided it’s rendered as text and the whitespace is preserved.
     # Very long text might be abbreviated in the UI.
@@ -42,6 +47,11 @@ module Raven
     # This defines the level of the event. If not provided it defaults
     # to `info` which is the middle level.
     property level : Severity?
+
+    # ditto
+    def level=(severity : Symbol)
+      @level = Severity.parse(severity.to_s)
+    end
 
     # Data associated with this breadcrumb. Contains a sub-object whose
     # contents depend on the breadcrumb `type`. Additional parameters that

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -20,8 +20,8 @@ module Raven
     DEFAULT_PROCESSORS = [
       Processor::RemoveCircularReferences,
       # Processor::RemoveStacktrace,
-      # Processor::Cookies,
-      # Processor::PostData,
+      Processor::Cookies,
+      Processor::PostData,
       Processor::HTTPHeaders,
       Processor::UTF8Conversion,
       Processor::SanitizeData,

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -33,12 +33,12 @@ module Raven
     # to set this to something like `/(src|engines)/`
     property app_dirs_pattern = /src/
 
+    # `Regex` pattern matched against `Backtrace::Line#file`.
+    property in_app_pattern : Regex { /^(#{SRC_PATH}\/)?(#{app_dirs_pattern})/ }
+
     # Path pattern matching directories to be recognized as your app modules.
     # Defaults to standard Shards setup (`lib/shard-name/...`).
     property modules_path_pattern = %r{^lib/(?<name>[^/]+)}
-
-    # `Regex` pattern matched against `Backtrace::Line#file`.
-    property in_app_pattern : Regex { /^(#{SRC_PATH}\/)?(#{app_dirs_pattern})/ }
 
     # Provide a `Proc` object that responds to `call` to send
     # events asynchronously, or pass `true` to to use standard `spawn`.

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -147,7 +147,7 @@ module Raven
     property? send_modules = true
 
     # Simple server string - set this to the DSN found on your Sentry settings.
-    getter server : String?
+    getter dsn : String?
 
     # Hostname as an FQDN.
     property server_name : String?
@@ -192,16 +192,16 @@ module Raven
 
       # try runtime ENV variable first
       if dsn = ENV["SENTRY_DSN"]?
-        self.server = dsn
+        self.dsn = dsn
       end
       # then try compile-time ENV variable
       # overwrites runtime if set
       {% if dsn = env("SENTRY_DSN") %}
-        self.server = {{dsn}}
+        self.dsn = {{dsn}}
       {% end %}
     end
 
-    def server=(uri : URI)
+    def dsn=(uri : URI)
       uri_path = uri.path.try &.split('/')
 
       if uri.user
@@ -225,15 +225,15 @@ module Raven
       @path = nil if @path.try &.empty?
 
       # For anyone who wants to read the base server string
-      @server = String.build do |str|
+      @dsn = String.build do |str|
         str << "#{@scheme}://#{@host}"
         str << ":#{@port}" if @port
         str << "#{@path}" if @path
       end
     end
 
-    def server=(value : String)
-      self.server = URI.parse(value)
+    def dsn=(value : String)
+      self.dsn = URI.parse(value)
     end
 
     def capture_allowed?(message_or_exc = nil)
@@ -296,7 +296,7 @@ module Raven
 
     private def valid?
       valid = true
-      if server
+      if dsn
         {% for key in REQUIRED_OPTIONS %}
           unless {{ "self.#{key.id}".id }}
             valid = false

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -33,8 +33,13 @@ module Raven
     # Indicates when the logging record was created (in the Sentry SDK).
     property timestamp : Time
 
-    # The record severity. Defaults to `Severity::ERROR`.
-    property level : Event::Severity?
+    # The record severity. Defaults to `:error`.
+    property level : Severity?
+
+    # ditto
+    def level=(severity : Symbol)
+      @level = Severity.parse(severity.to_s)
+    end
 
     # The name of the logger which created the record.
     property logger : String?

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -267,5 +267,9 @@ module Raven
       # data.compact!
       data.to_h
     end
+
+    def to_json(json : JSON::Builder)
+      to_hash.to_json(json)
+    end
   end
 end

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -2,6 +2,8 @@ require "secure_random"
 
 module Raven
   class Event
+    include Mixin::InitializeWith
+
     enum Severity
       DEBUG
       INFO
@@ -180,27 +182,6 @@ module Raven
       user.merge! @context.user
       extra.merge! @context.extra
       tags.merge! @configuration.tags, @context.tags
-    end
-
-    def initialize_with(**attributes)
-      {% begin %}
-        %set = false
-        {% for method in @type.methods.select { |m| m.name.ends_with?('=') && m.args.size == 1 } %}
-          {% ivar_name = method.name[0...-1].id %}
-          if arg = attributes[:{{ivar_name}}]?
-            self.{{ivar_name}} = arg
-            %set = true
-          end
-        {% end %}
-        unless %set
-          {% for var in @type.instance_vars %}
-            if arg = attributes[:{{var.name.id}}]?
-              @{{var.name.id}} = arg if arg.is_a?({{var.type.id}})
-            end
-          {% end %}
-        end
-      {% end %}
-      self
     end
 
     def message

--- a/src/raven/ext/exception.cr
+++ b/src/raven/ext/exception.cr
@@ -1,0 +1,3 @@
+class Exception
+  any_json_property :__raven_context
+end

--- a/src/raven/instance.cr
+++ b/src/raven/instance.cr
@@ -8,7 +8,7 @@ module Raven
   #   def initialize
   #     @other_raven = Raven::Instance.new
   #     @other_raven.configure do |config|
-  #       config.server = "http://..."
+  #       config.dsn = "http://..."
   #     end
   #   end
   #
@@ -61,7 +61,7 @@ module Raven
     #
     # ```
     # Raven.configure do |config|
-    #   config.server = "http://..."
+    #   config.dsn = "http://..."
     # end
     # ```
     def configure

--- a/src/raven/integrations/kemal/exception_handler.cr
+++ b/src/raven/integrations/kemal/exception_handler.cr
@@ -38,6 +38,9 @@ module Raven
             query_string: request.query,
             data:         data,
           }
+          if context.responds_to?(:kemal_authorized_username?)
+            event.user[:username] ||= context.kemal_authorized_username?
+          end
         end
         # Raven.annotate_exception exception, ...
         # pp ex

--- a/src/raven/integrations/kemal/exception_handler.cr
+++ b/src/raven/integrations/kemal/exception_handler.cr
@@ -42,8 +42,6 @@ module Raven
             event.user[:username] ||= context.kemal_authorized_username?
           end
         end
-        # Raven.annotate_exception exception, ...
-        # pp ex
         raise ex
       end
     end

--- a/src/raven/integrations/kemal/log_handler.cr
+++ b/src/raven/integrations/kemal/log_handler.cr
@@ -42,9 +42,9 @@ module Raven
 
             Raven.breadcrumbs.record do |crumb|
               unless (200...400).includes? context.response.status_code
-                crumb.level = Breadcrumb::Severity::ERROR
+                crumb.level = :error
               end
-              crumb.type = Breadcrumb::Type::HTTP
+              crumb.type = :http
               crumb.category = "kemal.request"
               crumb.data = {
                 method:      context.request.method.upcase,

--- a/src/raven/interface.cr
+++ b/src/raven/interface.cr
@@ -1,5 +1,7 @@
 module Raven
   abstract class Interface
+    include Mixin::InitializeWith
+
     class_getter registered = {} of Symbol => Interface.class
 
     def self.[](name : Symbol)
@@ -26,15 +28,6 @@ module Raven
         initialize_with(**attributes)
         yield self
       end
-    end
-
-    def initialize_with(**attributes)
-      {% for var in @type.instance_vars %}
-        if %arg = attributes[:{{var.name.id}}]?
-          @{{var.name.id}} = %arg
-        end
-      {% end %}
-      self
     end
 
     def to_hash

--- a/src/raven/interfaces/template.cr
+++ b/src/raven/interfaces/template.cr
@@ -1,0 +1,14 @@
+module Raven
+  class Interface::Template < Interface
+    property abs_path : String?
+    property filename : String?
+    property pre_context : Array(String)?
+    property context_line : String?
+    property lineno : Int32?
+    property post_context : Array(String)?
+
+    def self.sentry_alias
+      :template
+    end
+  end
+end

--- a/src/raven/mixins/initialize_with.cr
+++ b/src/raven/mixins/initialize_with.cr
@@ -1,0 +1,43 @@
+module Raven
+  module Mixin
+    # Maps passed *attributes* to `@ivar_variables` and `self.property_setters=`.
+    #
+    # ```
+    # class Foo
+    #   include Raven::Mixin::InitializeWith
+    #
+    #   @logger : String?
+    #   property message : String?
+    #
+    #   def backtrace=(backtrace)
+    #     # ...
+    #   end
+    # end
+    #
+    # foo = Foo.new
+    # foo.initialize_with({
+    #   logger:    "my-logger",
+    #   message:   "boo!",
+    #   backtrace: caller,
+    # })
+    # ```
+    #
+    # NOTE: Magic inside!
+    module InitializeWith
+      def initialize_with(**attributes)
+        {% for method in @type.methods.select { |m| m.name.ends_with?('=') && m.args.size == 1 } %}
+          {% property_name = method.name[0...-1].id %}
+          if arg = attributes[:{{property_name}}]?
+            self.{{property_name}} = arg
+          end
+        {% end %}
+        {% for var in @type.instance_vars %}
+          if arg = attributes[:{{var.name.id}}]?
+            @{{var.name.id}} = arg if arg.is_a?({{var.type.id}})
+          end
+        {% end %}
+        self
+      end
+    end
+  end
+end

--- a/src/raven/transports/http.cr
+++ b/src/raven/transports/http.cr
@@ -23,7 +23,7 @@ module Raven
         logger.debug "Event not sent: #{configuration.error_messages}"
         return
       end
-      logger.debug "HTTP Transport connecting to #{configuration.server}"
+      logger.debug "HTTP Transport connecting to #{configuration.dsn}"
 
       project_id = configuration.project_id
       path = configuration.path.try &.chomp '/'

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "0.3.1-dev"
+  VERSION = "0.4.0"
 end

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "0.3.0"
+  VERSION = "0.3.1-dev"
 end


### PR DESCRIPTION
### DONE:
- Renamed `Configuration#server` to `Configuration#dsn`
- Enabled removing cookies and POST data by default
- Made `Event` and `Breadcrumb` setters accept symbols in place of enum values, allowing to write
`event.level = :info` instead of `event.level = Raven::Event::Severity::INFO`
- Added `Event#to_json` convenience method for serialization
- Added `Interface::Template`
- Username provided by [kemalcr/kemal-basic-auth](https://github.com/kemalcr/kemal-basic-auth) is sent as a part of the user context