### PR TITLE
v0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,52 @@ Raven.extra_context happiness: "very"
 
 For more information, see [Context](https://docs.sentry.io/clients/ruby/context/).
 
+## Crash Handler
+
+Since Crystal doesn't provide native handlers for unhandled exceptions
+and sigfaults, *raven.cr* introduces its own crash handler compiled as
+external binary.
+
+### Setup
+
+Easiest way of using it is adding appropriate entry to project's `shard.yml`:
+
+```yaml
+targets:
+  # other target definitions if any...
+
+  sentry.crash_handler:
+    main: lib/raven/src/crash_handler.cr
+```
+
+With above entry defined in `targets`, running `shards build` should result in
+binary built in `bin/sentry.crash_handler`.
+
+__NOTE__: While building you might specify `SENTRY_DSN` env variable, which will be
+compiled into the binary (as plain-text) and used by the handler as
+*Sentry* endpoint.
+
+```bash
+SENTRY_DSN=<private_dsn> shards build sentry.crash_handler
+```
+
+Pass `--release` flag to disable debug messages.
+
+### Usage
+
+You need to run your app with previously built `bin/sentry.crash_handler` in
+front.
+
+```bash
+bin/sentry.crash_handler bin/your_app --some arguments --passed to your program
+```
+
+As one would expect, `STDIN` is passed to the original process, while
+`STDOUT` and `STDERR` are piped back from it.
+
+__NOTE__: You can always pass `SENTRY_DSN` env variable during execution
+in case you didn't do it while building the wrapper.
+
 ## More Information
 
 * [Documentation](https://docs.sentry.io/clients/ruby)

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ yet there are no tests written, so use it at your own risk! - or kindly send a P
 - [x] Integrations ([Kemal](https://github.com/kemalcr/kemal), [Sidekiq.cr](https://github.com/mperham/sidekiq.cr))
 - [x] Async support
 - [x] User Feedback (`Raven.send_feedback` + Kemal handler)
+- [x] Crash handler
 
 ### TODO
 
 - [ ] Tests
 - [ ] Exponential backoff in case of connection error
 - [ ] Caching unsent events for later send
-- [ ] Catching app crashes, kind of a bin wrapper perhaps?
 
 ## Installation
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 0.7.0
+version: 0.7.1-dev
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,10 @@ dependencies:
   any_hash:
     github: sija/any_hash.cr
 
+targets:
+  crash_handler:
+    main: src/crash_handler.cr
+
 crystal: 0.22.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ dependencies:
   any_hash:
     github: sija/any_hash.cr
 
-crystal: 0.21.1
+crystal: 0.22.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 0.7.1-dev
+version: 0.8.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -1,0 +1,205 @@
+require "./raven"
+
+module Raven
+  class CrashHandler
+    # Example:
+    #
+    # ```
+    # Invalid memory access (signal 11) at address 0x20
+    # [0x1057a9fab] *CallStack::print_backtrace:Int32 +107
+    # [0x105798aac] __crystal_sigfault_handler +60
+    # [0x7fff9ca0652a] _sigtramp +26
+    # [0x105cb35a1] GC_realloc +50
+    # [0x1057870bb] __crystal_realloc +11
+    # [0x1057d3ecc] *Pointer(UInt8)@Pointer(T)#realloc<Int32>:Pointer(UInt8) +28
+    # [0x10578706c] __crystal_main +2940
+    # [0x105798128] main +40
+    # ```
+    CRYSTAL_CRASH_PATTERN = /([^\n]+)\n(\[#{Backtrace::Line::ADDR_FORMAT}\] .*)$/m
+
+    # Example:
+    #
+    # ```
+    # execvp: No such file or directory (Errno)
+    # 0x108a4ab85: *CallStack::unwind:Array(Pointer(Void)) at ??
+    # 0x108a4ab21: *CallStack#initialize:Array(Pointer(Void)) at ??
+    # 0x108a4aaf8: *CallStack::new:CallStack at ??
+    # 0x108a391d1: *raise<Errno>:NoReturn at ??
+    # 0x108a9fdf5: *Process::exec_internal<String, Array(Pointer(UInt8)), Nil, Bool, IO::FileDescriptor, IO::FileDescriptor, (IO::FileDescriptor | IO::MultiWriter), Nil>:Nil at ??
+    # 0x108a9f2de: *Process#initialize<String, Nil, Nil, Bool, Bool, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter, Nil>:Nil at ??
+    # 0x108a9ed3b: *Process::new<String, Nil, Nil, Bool, Bool, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter, Nil>:Process at ??
+    # 0x108a9ec65: *Process::run:input:output:error<String, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter>:Process::Status at ??
+    # 0x108a2d948: __crystal_main at ??
+    # 0x108a3f6a8: main at ??
+    # ```
+    CRYSTAL_EXCEPTION_PATTERN = /([^\n]+) \(([A-Z]\w+)\)\n(#{Backtrace::Line::ADDR_FORMAT}: .*)$/m
+
+    # Default event options.
+    DEFAULT_OPTS = {
+      logger:      "raven.crash_handler",
+      fingerprint: ["{{ default }}", "process.crash"],
+    }
+
+    # Process executable path.
+    property name : String
+    # An `Array` of arguments passed to process.
+    property args : Array(String)?
+
+    # FIXME: doesn't work yet due to usage of global Raven within `Backtrace::Line`.
+    #
+    # ```
+    # getter raven : Instance { Instance.new }
+    # ```
+    getter raven : Instance { Raven.instance }
+
+    delegate :context, :configuration, :configure, :capture,
+      to: raven
+
+    property logger : ::Logger {
+      Logger.new({{ flag?(:release) ? nil : "STDOUT".id }}).tap do |logger|
+        logger.level = {{ flag?(:debug) ? "Logger::DEBUG".id : "Logger::ERROR".id }}
+
+        "#{logger.progname}.crash_handler".tap do |progname|
+          logger.progname = progname
+          configuration.exclude_loggers << progname
+        end
+      end
+    }
+
+    def initialize(@name, @args)
+      context.extra.merge!({
+        process: {name: @name, args: @args},
+      })
+    end
+
+    private def configure!
+      configure do |config|
+        config.logger = logger
+        config.send_modules = false
+        config.processors = [
+          Processor::UTF8Conversion,
+          Processor::SanitizeData,
+          Processor::Compact,
+        ] of Processor.class
+      end
+    end
+
+    private def capture_with_options(*args, **options)
+      capture(*args) do |event|
+        event.initialize_with **DEFAULT_OPTS
+        event.initialize_with **options
+        yield event
+      end
+    end
+
+    private def capture_with_options(*args, **options)
+      capture_with_options(*args, **options) { }
+    end
+
+    private def capture_with_options(**options)
+      yield
+    rescue e : Raven::Error
+      raise e # Don't capture Raven errors
+    rescue e : Exception
+      capture_with_options(e, **options) { }
+      raise e
+    end
+
+    private def capture_crystal_exception(klass, msg, backtrace)
+      capture_with_options klass, msg, backtrace
+    end
+
+    private def capture_crystal_crash(msg, backtrace)
+      capture_with_options msg do |event|
+        event.level = :fatal
+        event.backtrace = backtrace
+        # we need to overwrite the fingerprint due to varied
+        # pointer addresses in crash messages, otherwise resulting
+        # in new event per crash
+        event.fingerprint.tap do |fingerprint|
+          fingerprint.delete "{{ default }}"
+          fingerprint << "process: #{name}"
+          if culprit = event.culprit
+            fingerprint << "culprit: #{culprit}"
+          end
+        end
+      end
+    end
+
+    private def capture_process_failure(exit_code, output, error)
+      msg = "Process #{name} exited with code #{exit_code}"
+      cmd = (args = @args) ? "#{name} #{args.join ' '}" : name
+
+      capture_with_options msg do |event|
+        event.culprit = cmd
+        event.extra.merge!({
+          output: output,
+          error:  error,
+        })
+      end
+    end
+
+    getter! started_at : Time
+    getter! process_status : Process::Status
+
+    delegate :exit_code, :success?,
+      to: process_status
+
+    private def run_process(output : IO = IO::Memory.new, error : IO = IO::Memory.new)
+      @process_status = Process.run command: name, args: args,
+        input: STDIN,
+        output: IO::MultiWriter.new(STDOUT, output),
+        error: IO::MultiWriter.new(STDERR, error)
+      {output.to_s.chomp, error.to_s.chomp}
+    end
+
+    def run : Void
+      configure!
+      @started_at = Time.now
+
+      capture_with_options do
+        output, error = run_process
+        running_for = Time.now - started_at
+
+        context.tags.merge!({
+          exit_code: exit_code,
+        })
+        context.extra.merge!({
+          running_for: running_for.to_s,
+          started_at:  started_at,
+        })
+
+        unless success?
+          # TODO: pluggable detectors
+          case error
+          when CRYSTAL_CRASH_PATTERN
+            _, msg, backtrace = $~
+            capture_crystal_crash(msg, backtrace)
+          when CRYSTAL_EXCEPTION_PATTERN
+            _, msg, klass, backtrace = $~
+            capture_crystal_exception(klass, msg, backtrace)
+          else
+            capture_process_failure(exit_code, output, error)
+          end
+        end
+
+        exit(exit_code)
+      end
+    end
+  end
+end
+
+if ARGV.empty?
+  puts "Usage: #{PROGRAM_NAME} <CMD> [OPTION]..."
+  exit(1)
+end
+
+name, args = ARGV[0], ARGV.size > 1 ? ARGV[1..-1] : nil
+handler = Raven::CrashHandler.new(name, args)
+handler.raven.tap do |raven|
+  raven.configuration.src_path = Dir.current
+  raven.user_context({
+    username: `whoami`.chomp,
+  })
+end
+handler.run

--- a/src/raven/backtrace.cr
+++ b/src/raven/backtrace.cr
@@ -1,6 +1,6 @@
 module Raven
   class Backtrace
-    IGNORED_LINES_PATTERN = /CallStack|caller:|raise<(.+?)>:NoReturn/
+    IGNORED_LINES_PATTERN = /_sigtramp|__crystal_(sigfault_handler|raise)|CallStack|caller:|raise<(.+?)>:NoReturn/
 
     class_getter default_filters = [
       ->(line : String) { line.match(IGNORED_LINES_PATTERN) ? nil : line },

--- a/src/raven/backtrace.cr
+++ b/src/raven/backtrace.cr
@@ -10,9 +10,7 @@ module Raven
 
     def self.parse(backtrace : Array(String), **options)
       filters = default_filters.dup
-      if f = options[:filters]?
-        filters.concat(f)
-      end
+      options[:filters]?.try { |f| filters.concat(f) }
 
       filtered_lines = backtrace.map do |line|
         filters.reduce(line) do |nested_line, proc|

--- a/src/raven/backtrace.cr
+++ b/src/raven/backtrace.cr
@@ -9,7 +9,7 @@ module Raven
     getter lines : Array(Line)
 
     def self.parse(backtrace : Array(String), **options)
-      filters = default_filters
+      filters = default_filters.dup
       if f = options[:filters]?
         filters.concat(f)
       end

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -20,6 +20,21 @@ module Raven
       # - `0x102ce57db: ~procProc(HTTP::Server::Context, String)@lib/kemal/src/kemal/route.cr:11 at ??`
       # - `0x1002d5180: ~procProc(HTTP::Server::Context, (File::PReader | HTTP::ChunkedContent | HTTP::Server::Response | HTTP::Server::Response::Output | HTTP::UnknownLengthContent | HTTP::WebSocket::Protocol::StreamIO | IO::ARGF | IO::Delimited | IO::FileDescriptor | IO::Hexdump | IO::Memory | IO::MultiWriter | IO::Sized | Int32 | OpenSSL::SSL::Socket | String::Builder | Zip::ChecksumReader | Zip::ChecksumWriter | Zlib::Deflate | Zlib::Inflate | Nil))@src/foo/bar/baz.cr:420 at ??`
       CRYSTAL_PROC: /^#{ADDR_FORMAT}: \~(?<method>[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+)) at \?+$/,
+
+      # Examples:
+      #
+      # - `[0x1057a9fab] *CallStack::print_backtrace:Int32 +107`
+      # - `[0x105798aac] __crystal_sigfault_handler +60`
+      # - `[0x7fff9ca0652a] _sigtramp +26`
+      # - `[0x105cb35a1] GC_realloc +50`
+      # - `[0x1057870bb] __crystal_realloc +11`
+      # - `[0x1057d3ecc] *Pointer(UInt8)@Pointer(T)#realloc<Int32>:Pointer(UInt8) +28`
+      # - `[0x105965e03] *Foo::Bar#bar!:Nil +195`
+      # - `[0x10579f5c1] *naughty_bar:Nil +17`
+      # - `[0x10579f5a9] *naughty_foo:Nil +9`
+      # - `[0x10578706c] __crystal_main +2940`
+      # - `[0x105798128] main +40`
+      CRYSTAL_CRASH: /^\[#{ADDR_FORMAT}\] \*?(?<method>.*?) \+\d+(?: \((?<times>\d+) times\))?$/,
     }
 
     # The file portion of the line (such as `app/models/user.cr`).

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -1,30 +1,26 @@
 module Raven
   # Handles backtrace parsing line by line
   struct Backtrace::Line
-    # Examples:
-    #
-    # - `0x103a7bbee: __crystal_main at ??`
-    # - `0x100e1ea72: *CallStack::unwind:Array(Pointer(Void)) at ??`
-    # - `0x102dff5e7: *Foo::Bar#_baz:Foo::Bam at /home/fooBAR/code/awesome-shard.cr/lib/foo/src/foo/bar.cr 50:7`
-    # - `0x102de9035: *Foo::Bar::bar_by_id<String>:Foo::Bam at /home/fooBAR/code/awesome-shard.cr/lib/foo/src/foo/bar.cr 29:9`
-    # - `0x102cfe8f4: *Fiber#run:(IO::FileDescriptor | Nil) at /usr/local/Cellar/crystal-lang/0.20.5_2/src/fiber.cr 114:3`
-    CRYSTAL_METHOD_FORMAT = /\*?(?<method>.*?) at (?<file>[^:]+)(?:\s(?<line>\d+)(?:\:(?<col>\d+))?)?$/
+    # :nodoc:
+    ADDR_FORMAT = /(?<addr>0x[a-f0-9]+)/i
 
-    # Examples:
-    #
-    # - `0x102cee376: ~procProc(Nil)@/usr/local/Cellar/crystal-lang/0.20.5_2/src/http/server.cr:148 at ??`
-    # - `0x102ce57db: ~procProc(HTTP::Server::Context, String)@lib/kemal/src/kemal/route.cr:11 at ??`
-    # - `0x1002d5180: ~procProc(HTTP::Server::Context, (File::PReader | HTTP::ChunkedContent | HTTP::Server::Response | HTTP::Server::Response::Output | HTTP::UnknownLengthContent | HTTP::WebSocket::Protocol::StreamIO | IO::ARGF | IO::Delimited | IO::FileDescriptor | IO::Hexdump | IO::Memory | IO::MultiWriter | IO::Sized | Int32 | OpenSSL::SSL::Socket | String::Builder | Zip::ChecksumReader | Zip::ChecksumWriter | Zlib::Deflate | Zlib::Inflate | Nil))@src/foo/bar/baz.cr:420 at ??`
-    CRYSTAL_PROC_FORMAT = /\~(?<proc_method>[^@]+)@(?<proc_file>[^:]+)(?:\:(?<proc_line>\d+)) at \?+$/
+    CALLSTACK_PATTERNS = {
+      # Examples:
+      #
+      # - `0x103a7bbee: __crystal_main at ??`
+      # - `0x100e1ea72: *CallStack::unwind:Array(Pointer(Void)) at ??`
+      # - `0x102dff5e7: *Foo::Bar#_baz:Foo::Bam at /home/fooBAR/code/awesome-shard.cr/lib/foo/src/foo/bar.cr 50:7`
+      # - `0x102de9035: *Foo::Bar::bar_by_id<String>:Foo::Bam at /home/fooBAR/code/awesome-shard.cr/lib/foo/src/foo/bar.cr 29:9`
+      # - `0x102cfe8f4: *Fiber#run:(IO::FileDescriptor | Nil) at /usr/local/Cellar/crystal-lang/0.20.5_2/src/fiber.cr 114:3`
+      CRYSTAL_METHOD: /^#{ADDR_FORMAT}: \*?(?<method>.*?) at (?<file>[^:]+)(?:\s(?<line>\d+)(?:\:(?<col>\d+))?)?$/,
 
-    # See `CRYSTAL_PROC_FORMAT` and `CRYSTAL_METHOD_FORMAT`.
-    #
-    # Examples:
-    #
-    # - `0x103a7bbee: __crystal_main at ??`
-    # - `0x102cfe8f4: *Fiber#run:(IO::FileDescriptor | Nil) at /usr/local/Cellar/crystal-lang/0.20.5_2/src/fiber.cr 114:3`
-    # - `0x102cee376: ~procProc(Nil)@/usr/local/Cellar/crystal-lang/0.20.5_2/src/http/server.cr:148 at ??`
-    CRYSTAL_INPUT_FORMAT = /^(?<addr>0x[a-z0-9]+): #{CRYSTAL_PROC_FORMAT + CRYSTAL_METHOD_FORMAT}/
+      # Examples:
+      #
+      # - `0x102cee376: ~procProc(Nil)@/usr/local/Cellar/crystal-lang/0.20.5_2/src/http/server.cr:148 at ??`
+      # - `0x102ce57db: ~procProc(HTTP::Server::Context, String)@lib/kemal/src/kemal/route.cr:11 at ??`
+      # - `0x1002d5180: ~procProc(HTTP::Server::Context, (File::PReader | HTTP::ChunkedContent | HTTP::Server::Response | HTTP::Server::Response::Output | HTTP::UnknownLengthContent | HTTP::WebSocket::Protocol::StreamIO | IO::ARGF | IO::Delimited | IO::FileDescriptor | IO::Hexdump | IO::Memory | IO::MultiWriter | IO::Sized | Int32 | OpenSSL::SSL::Socket | String::Builder | Zip::ChecksumReader | Zip::ChecksumWriter | Zlib::Deflate | Zlib::Inflate | Nil))@src/foo/bar/baz.cr:420 at ??`
+      CRYSTAL_PROC: /^#{ADDR_FORMAT}: \~(?<method>[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+)) at \?+$/,
+    }
 
     # The file portion of the line (such as `app/models/user.cr`).
     getter file : String?
@@ -42,16 +38,19 @@ module Raven
       value =~ /^\?+$/
     end
 
+    private def self.nil_on_empty(value)
+      empty_marker?(value) ? nil : value
+    end
+
     # Parses a single line of a given backtrace, where *unparsed_line* is
     # the raw line from `caller` or some backtrace.
     # Returns the parsed backtrace line.
     def self.parse(unparsed_line : String) : Line
-      if match = unparsed_line.match(CRYSTAL_INPUT_FORMAT)
-        file = match["proc_file"]? || match["file"]?
-        file = nil if empty_marker?(file)
-        number = match["proc_line"]? || match["line"]?
-        column = match["col"]?
-        method = match["proc_method"]? || match["method"]?
+      if CALLSTACK_PATTERNS.values.any? &.match(unparsed_line)
+        file = nil_on_empty $~["file"]?
+        number = $~["line"]?
+        column = $~["col"]?
+        method = $~["method"]?
       end
       new(file, number.try(&.to_i), column.try(&.to_i), method)
     end

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -73,8 +73,11 @@ module Raven
       io << "<Line: " << self << ">"
     end
 
+    # FIXME: untangle it from global `Raven`.
+    protected delegate :configuration, to: Raven
+
     def under_src_path?
-      return unless src_path = Configuration::SRC_PATH
+      return unless src_path = configuration.src_path
       file.try &.starts_with?(src_path)
     end
 
@@ -82,19 +85,19 @@ module Raven
       return unless path = file
       return path unless path.starts_with?('/')
       return unless under_src_path?
-      if prefix = Configuration::SRC_PATH
+      if prefix = configuration.src_path
         path[prefix.chomp(File::SEPARATOR).size + 1..-1]
       end
     end
 
     def shard_name
       relative_path
-        .try &.match(Raven.configuration.modules_path_pattern)
+        .try &.match(configuration.modules_path_pattern)
         .try &.[]("name")
     end
 
     def in_app?
-      !!(file =~ Raven.configuration.in_app_pattern)
+      !!(file =~ configuration.in_app_pattern)
     end
   end
 end

--- a/src/raven/client.cr
+++ b/src/raven/client.cr
@@ -79,10 +79,10 @@ module Raven
 
     private def generate_auth_header
       fields = {
-        "sentry_version": PROTOCOL_VERSION,
-        "sentry_client":  USER_AGENT,
-        "sentry_key":     configuration.public_key,
-        "sentry_secret":  configuration.secret_key,
+        sentry_version: PROTOCOL_VERSION,
+        sentry_client:  USER_AGENT,
+        sentry_key:     configuration.public_key,
+        sentry_secret:  configuration.secret_key,
       }
       "Sentry " + fields.map { |key, value| "#{key}=#{value}" }.join(", ")
     end

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -3,9 +3,6 @@ require "json"
 
 module Raven
   class Configuration
-    # :nodoc:
-    SRC_PATH = {{ flag?(:debug) ? `pwd`.strip.stringify : nil }}
-
     # Array of required properties needed to be set, before
     # `Configuration` is considered valid.
     REQUIRED_OPTIONS = %i(host public_key secret_key project_id)
@@ -28,13 +25,16 @@ module Raven
       Processor::Compact,
     ] of Processor.class
 
+    # Used in `#in_app_pattern`.
+    property src_path : String? = {{ flag?(:debug) ? `pwd`.strip.stringify : nil }}
+
     # Directories to be recognized as part of your app. e.g. if you
     # have an `engines` dir at the root of your project, you may want
     # to set this to something like `/(src|engines)/`
     property app_dirs_pattern = /src/
 
     # `Regex` pattern matched against `Backtrace::Line#file`.
-    property in_app_pattern : Regex { /^(#{SRC_PATH}\/)?(#{app_dirs_pattern})/ }
+    property in_app_pattern : Regex { /^(#{src_path}\/)?(#{app_dirs_pattern})/ }
 
     # Path pattern matching directories to be recognized as your app modules.
     # Defaults to standard Shards setup (`lib/shard-name/...`).

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -65,7 +65,7 @@ module Raven
     #
     # NOTE: A value of `{{ default }}` will be replaced with the built-in behavior,
     # thus allowing you to extend it, or completely replace it.
-    property fingerprint : Array(String)?
+    property fingerprint : Array(String) { [] of String }
 
     # The environment name, such as `production` or `staging`.
     property environment : String?

--- a/src/raven/integrations/kemal.cr
+++ b/src/raven/integrations/kemal.cr
@@ -1,6 +1,10 @@
 require "kemal"
 
 module Raven
+  # ```
+  # require "raven/integrations/kemal"
+  # ```
+  #
   # It's recommended to enable `Configuration#async` when using Kemal.
   #
   # ```

--- a/src/raven/integrations/sidekiq.cr
+++ b/src/raven/integrations/sidekiq.cr
@@ -1,6 +1,9 @@
 require "sidekiq"
 
 module Raven
+  # ```
+  # require "raven/integrations/sidekiq"
+  # ```
   module Sidekiq
   end
 end

--- a/src/raven/processors/sanitize_data.cr
+++ b/src/raven/processors/sanitize_data.cr
@@ -41,7 +41,7 @@ module Raven
         value.map! { |i| process(key, i).as(typeof(i)) }
       when String
         case
-        when value.to_s =~ fields_pattern && (json = parse_json_or_nil(value))
+        when value =~ fields_pattern && (json = parse_json_or_nil(value))
           process(json).to_json
         when matches_regexes?(key, value)
           STRING_MASK

--- a/src/raven/processors/sanitize_data.cr
+++ b/src/raven/processors/sanitize_data.cr
@@ -66,7 +66,7 @@ module Raven
       query_hash = HTTP::Params.parse(query_string).to_h
       query_hash = process(query_hash)
       query_hash = query_hash.map { |k, v| [k.as(String), v.as(String)] }.to_h rescue nil
-      HTTP::Params.from_hash(query_hash).to_s if query_hash
+      HTTP::Params.encode(query_hash).to_s if query_hash
     end
 
     private def matches_regexes?(key, value)

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "0.7.0"
+  VERSION = "0.7.1-dev"
 end

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "0.7.1-dev"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
### DONE:
- Bumped minimal required Crystal version to `0.22.0`
- Added Crash Handler feature, closes #13 
- Added `Configuration#src_path` property
- Added `Raven.capture(klass, message)` method variant
- Made `Event#fingerprint` lazy and removed nilibility from returned type
- Fixed `Backtrace.parse`, so it doesn't mutate `Backtrace.default_filters`