### PR TITLE
fixed macro initialize with using name (returns Array(...Frame)) inst…

### DIFF
--- a/src/raven/mixins/initialize_with.cr
+++ b/src/raven/mixins/initialize_with.cr
@@ -41,7 +41,7 @@ module Raven
           {% end %}
 
           {% ivars = @type.instance_vars %}
-          {% ivars = ivars.map { |i| [i.name.id, i.type.id] }.uniq %}
+          {% ivars = ivars.map { |i| [i.name.id, i.type.name] }.uniq %}
 
           {% for ivar in ivars %}
             {% name = ivar[0]; type = ivar[1] %}


### PR DESCRIPTION
fixed macro initialize with using name (returns Array(...Frame)) instead of id (Array(...Frame)+) fixes #19