### PR TITLE
Replace deprecated SecureRandom with Random module

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.22.0
+crystal: 0.24.1
 
 license: MIT

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -1,4 +1,4 @@
-require "secure_random"
+require "random"
 
 module Raven
   class Event
@@ -152,7 +152,7 @@ module Raven
       @configuration = options[:configuration]? || Raven.configuration
       @breadcrumbs = options[:breadcrumbs]? || Raven.breadcrumbs
       @context = options[:context]? || Raven.context
-      @id = SecureRandom.uuid.delete('-')
+      @id = Random.new.base64
       @timestamp = Time.now
       @server_name = @configuration.server_name
       @release = @configuration.release

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Addresses a small incompatibility with Crystal `0.24.1`