### PR TITLE
compatibility with crystal 0.26.0 and kemal 0.24.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.25.0
+crystal: 0.26.0
 
 license: MIT

--- a/src/raven/integrations/kemal/exception_handler.cr
+++ b/src/raven/integrations/kemal/exception_handler.cr
@@ -26,7 +26,7 @@ module Raven
       end
 
       def build_raven_culprit_context(context : HTTP::Server::Context)
-        context.route if context.route_defined?
+        context.route if context.route_found?
       end
 
       def build_raven_http_url(context : HTTP::Server::Context)

--- a/src/raven/integrations/kemal/log_handler.cr
+++ b/src/raven/integrations/kemal/log_handler.cr
@@ -23,7 +23,7 @@ module Raven
       def initialize(@wrapped = nil)
       end
 
-      def next=(handler : HTTP::Handler | Proc | Nil)
+      def next=(handler : HTTP::Handler | HTTP::Handler::HandlerProc | Nil)
         @wrapped.try(&.next=(handler)) || (@next = handler)
       end
 


### PR DESCRIPTION
## Crystal

`HTTP::Handler::Proc` renamed to `HTTP::Handler::HandlerProc` (https://github.com/crystal-lang/crystal/pull/6453/commits/e51a3f2c4898c670b8fec5d9440624db4b944c2c)

## Kemal

`route_defined?` renamed to `route_found?` (https://github.com/kemalcr/kemal/commit/e468e2e340f23d0a0e4b0c86c2c3dc1f58c23fdc)