### PR TITLE
v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   raven:
-    github: sija/raven.cr
+    github: Sija/raven.cr
 ```
 
 ## Usage
@@ -60,7 +60,7 @@ end
 ### Raven doesn't report some kinds of data by default.
 
 Raven ignores some exceptions by default - most of these are related to 404s or
-controller actions not being found. [For a complete list, see the `IGNORE_DEFAULT` constant](https://github.com/sija/raven.cr/blob/master/src/raven/configuration.cr).
+controller actions not being found. [For a complete list, see the `IGNORE_DEFAULT` constant](https://github.com/Sija/raven.cr/blob/master/src/raven/configuration.cr).
 
 Raven doesn't report `POST`, `PUT`, `PATCH` data or cookies by default.
 In addition, it will attempt to remove any obviously sensitive data,
@@ -237,8 +237,8 @@ in case you didn't do it while building the wrapper.
 ## More Information
 
 * [Documentation](https://docs.sentry.io/clients/ruby)
-* [Bug Tracker](https://github.com/sija/raven.cr/issues)
-* [Code](https://github.com/sija/raven.cr)
+* [Bug Tracker](https://github.com/Sija/raven.cr/issues)
+* [Code](https://github.com/Sija/raven.cr)
 * [Mailing List](https://groups.google.com/group/getsentry)
 * [IRC](irc://irc.freenode.net/sentry) (irc.freenode.net, #sentry)
 
@@ -250,12 +250,12 @@ crystal spec
 
 ## Contributing
 
-1. [Fork it](https://github.com/sija/raven.cr/fork)
+1. [Fork it](https://github.com/Sija/raven.cr/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new [Pull Request](https://github.com/sija/raven.cr/pulls)
+5. Create a new [Pull Request](https://github.com/Sija/raven.cr/pulls)
 
 ## Contributors
 
-- [sija](https://github.com/sija) Sijawusz Pur Rahnama - creator, maintainer
+- [@Sija](https://github.com/Sija) Sijawusz Pur Rahnama - creator, maintainer

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ end
 
 ### Raven doesn't report some kinds of data by default.
 
-Raven ignores some exceptions by default - most of these are related to 404s or
-controller actions not being found. [For a complete list, see the `IGNORE_DEFAULT` constant](https://github.com/Sija/raven.cr/blob/master/src/raven/configuration.cr).
+If used with integrations, Raven ignores some exceptions by default - most of
+these are related to 404s or controller actions not being found.
 
 Raven doesn't report `POST`, `PUT`, `PATCH` data or cookies by default.
 In addition, it will attempt to remove any obviously sensitive data,
@@ -101,8 +101,9 @@ Raven.configure do |config|
 end
 ```
 
-And, while not necessary if using `SENTRY_DSN`, you can also provide an `environments`
-setting. Raven will only capture events when `KEMAL_ENV` matches an environment in the list.
+And, while not necessary if using `SENTRY_DSN`, you can also provide an
+`environments` setting. Raven will only capture events when
+`SENTRY_CURRENT_ENV` or `KEMAL_ENV` matches an environment in the list.
 
 ```crystal
 Raven.configure do |config|

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 
 begin
   1 / 0
-rescue ex : DivisionByZero
+rescue ex : DivisionByZeroError
   Raven.capture(ex)
 end
 ```

--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   any_hash:
     github: sija/any_hash.cr
-    version: 0.2.1
+    version: 0.2.2
 
 development_dependencies:
   timecop:

--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.25.0
+crystal: 0.26.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.0.0-rc3
+version: 1.0.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ development_dependencies:
     github: TobiasGSmollett/timecop.cr
   ameba:
     github: veelenga/ameba
-    version: 0.7.0
+    version: 0.8.0
 
 targets:
   crash_handler:

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 dependencies:
   any_hash:
-    github: sija/any_hash.cr
+    github: Sija/any_hash.cr
     version: 0.2.2
 
 development_dependencies:

--- a/spec/raven/configuration_spec.cr
+++ b/spec/raven/configuration_spec.cr
@@ -143,7 +143,6 @@ describe Raven::Configuration do
         configuration.capture_allowed?.should be_false
         configuration.errors.should eq([
           "No :public_key specified",
-          "No :secret_key specified",
           "No :project_id specified",
         ])
       end

--- a/spec/raven/processors/sanitize_data_spec.cr
+++ b/spec/raven/processors/sanitize_data_spec.cr
@@ -156,7 +156,7 @@ describe Raven::Processor::SanitizeData do
   it "should filter credit card values" do
     data = {
       "ccnumba"     => "4242424242424242",
-      "ccnumba_int" => 4242424242424242, # ameba:disable LargeNumbers
+      "ccnumba_int" => 4242424242424242,
     }
 
     result = processor.process(data)
@@ -171,12 +171,12 @@ describe Raven::Processor::SanitizeData do
 
       data = {
         "ccnumba"     => "4242424242424242",
-        "ccnumba_int" => 4242424242424242, # ameba:disable LargeNumbers
+        "ccnumba_int" => 4242424242424242,
       }
 
       result = processor.process(data)
       result["ccnumba"].should eq("4242424242424242")
-      result["ccnumba_int"].should eq(4242424242424242) # ameba:disable LargeNumbers
+      result["ccnumba_int"].should eq(4242424242424242)
     end
   end
 

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -20,19 +20,14 @@ module Raven
     # Example:
     #
     # ```
-    # execvp: No such file or directory (Errno)
-    # 0x108a4ab85: *CallStack::unwind:Array(Pointer(Void)) at ??
-    # 0x108a4ab21: *CallStack#initialize:Array(Pointer(Void)) at ??
-    # 0x108a4aaf8: *CallStack::new:CallStack at ??
-    # 0x108a391d1: *raise<Errno>:NoReturn at ??
-    # 0x108a9fdf5: *Process::exec_internal<String, Array(Pointer(UInt8)), Nil, Bool, IO::FileDescriptor, IO::FileDescriptor, (IO::FileDescriptor | IO::MultiWriter), Nil>:Nil at ??
-    # 0x108a9f2de: *Process#initialize<String, Nil, Nil, Bool, Bool, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter, Nil>:Nil at ??
-    # 0x108a9ed3b: *Process::new<String, Nil, Nil, Bool, Bool, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter, Nil>:Process at ??
-    # 0x108a9ec65: *Process::run:input:output:error<String, IO::FileDescriptor, IO::FileDescriptor, IO::MultiWriter>:Process::Status at ??
-    # 0x108a2d948: __crystal_main at ??
-    # 0x108a3f6a8: main at ??
+    # Unhandled exception: Index out of bounds (IndexError)
+    #   from /usr/local/Cellar/crystal/0.26.0/src/indexable.cr:596:8 in 'at'
+    #   from /eval:1:1 in '__crystal_main'
+    #   from /usr/local/Cellar/crystal/0.26.0/src/crystal/main.cr:104:5 in 'main_user_code'
+    #   from /usr/local/Cellar/crystal/0.26.0/src/crystal/main.cr:93:7 in 'main'
+    #   from /usr/local/Cellar/crystal/0.26.0/src/crystal/main.cr:133:3 in 'main'
     # ```
-    CRYSTAL_EXCEPTION_PATTERN = /([^\n]+) \(([A-Z]\w+)\)\n(#{Backtrace::Line::ADDR_FORMAT}: .*)$/m
+    CRYSTAL_EXCEPTION_PATTERN = /Unhandled exception: ([^\n]+) \(([A-Z]\w+)\)\n(.*)$/m
 
     # Default event options.
     DEFAULT_OPTS = {
@@ -177,6 +172,7 @@ module Raven
             capture_crystal_crash(msg, backtrace)
           when CRYSTAL_EXCEPTION_PATTERN
             _, msg, klass, backtrace = $~
+            backtrace = backtrace.gsub /^\s*from\s*/m, ""
             capture_crystal_exception(klass, msg, backtrace)
           else
             capture_process_failure(exit_code, output, error)

--- a/src/raven.cr
+++ b/src/raven.cr
@@ -27,7 +27,7 @@ module Raven
 
   def self.sys_command(command)
     result = `(#{command}) 2>/dev/null`.strip rescue nil
-    # ameba:disable NegatedConditionsInUnless
+    # ameba:disable Style/NegatedConditionsInUnless
     result unless result.nil? || result.empty? || !$?.success?
   end
 end

--- a/src/raven/backtrace.cr
+++ b/src/raven/backtrace.cr
@@ -18,9 +18,7 @@ module Raven
         end
       end.compact
 
-      lines = filtered_lines.map do |unparsed_line|
-        Line.parse(unparsed_line)
-      end
+      lines = filtered_lines.map &->Line.parse(String)
       new(lines)
     end
 

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -10,14 +10,14 @@ module Raven
       # - `lib/foo/src/foo/bar.cr:50:7 in '*Foo::Bar#_baz:Foo::Bam'`
       # - `lib/foo/src/foo/bar.cr:29:9 in '*Foo::Bar::bar_by_id<String>:Foo::Bam'`
       # - `/usr/local/Cellar/crystal-lang/0.24.1/src/fiber.cr:114:3 in '*Fiber#run:(IO::FileDescriptor | Nil)'`
-      CRYSTAL_METHOD: /^(?<file>[^:]+)(?:\:(?<line>\d+)(?:\:(?<col>\d+))?)? in '\*?(?<method>.*?)'( at #{ADDR_FORMAT})?$/,
+      CRYSTAL_METHOD: /^(?<file>[^:]+)(?:\:(?<line>\d+)(?:\:(?<col>\d+))?)? in '\*?(?<method>.*?)'(?: at #{ADDR_FORMAT})?$/,
 
       # Examples:
       #
       # - `~procProc(Nil)@/usr/local/Cellar/crystal-lang/0.24.1/src/http/server.cr:148 at 0x102cee376`
       # - `~procProc(HTTP::Server::Context, String)@lib/kemal/src/kemal/route.cr:11 at 0x102ce57db`
       # - `~procProc(HTTP::Server::Context, (File::PReader | HTTP::ChunkedContent | HTTP::Server::Response | HTTP::Server::Response::Output | HTTP::UnknownLengthContent | HTTP::WebSocket::Protocol::StreamIO | IO::ARGF | IO::Delimited | IO::FileDescriptor | IO::Hexdump | IO::Memory | IO::MultiWriter | IO::Sized | Int32 | OpenSSL::SSL::Socket | String::Builder | Zip::ChecksumReader | Zip::ChecksumWriter | Zlib::Deflate | Zlib::Inflate | Nil))@src/foo/bar/baz.cr:420`
-      CRYSTAL_PROC: /^(?<method>~[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+))( at #{ADDR_FORMAT})?$/,
+      CRYSTAL_PROC: /^(?<method>~[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+))(?: at #{ADDR_FORMAT})?$/,
 
       # Examples:
       #
@@ -75,16 +75,18 @@ module Raven
 
     # Reconstructs the line in a readable fashion
     def to_s(io)
-      io << '`' << method << '`' if method
-      if file
-        io << " at " << file
-        io << ':' << number if number
-        io << ':' << column if column
+      io << '`' << @method << '`' if @method
+      if @file
+        io << " at " << @file
+        io << ':' << @number if @number
+        io << ':' << @column if @column
       end
     end
 
     def inspect(io)
-      io << "Backtrace::Line(" << self << ')'
+      io << "Backtrace::Line("
+      to_s(io)
+      io << ')'
     end
 
     # FIXME: untangle it from global `Raven`.

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -79,6 +79,7 @@ module Raven
       if file
         io << " at " << file
         io << ':' << number if number
+        io << ':' << column if column
       end
     end
 

--- a/src/raven/client.cr
+++ b/src/raven/client.cr
@@ -84,8 +84,10 @@ module Raven
         sentry_version: PROTOCOL_VERSION,
         sentry_client:  USER_AGENT,
         sentry_key:     configuration.public_key,
-        sentry_secret:  configuration.secret_key,
       }
+      if secret_key = configuration.secret_key
+        fields = fields.merge(sentry_secret: secret_key)
+      end
       "Sentry " + fields.map { |key, value| "#{key}=#{value}" }.join(", ")
     end
 

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -71,7 +71,8 @@ module Raven
       }
     end
 
-    # `KEMAL_ENV` by default.
+    # Defaults to `SENTRY_CURRENT_ENV` or `KEMAL_ENV` `ENV` variables if set,
+    # `"default"` otherwise.
     property current_environment : String?
 
     # Encoding type for event bodies.
@@ -156,8 +157,8 @@ module Raven
     property? sanitize_credit_cards = true
 
     # By default, Sentry censors `Hash` values when their keys match things like
-    # `"secret"`, `"password"`, etc. Provide an `Array` of `String`s that, when matched in
-    # a hash key, will be censored and not sent to Sentry.
+    # `"secret"`, `"password"`, etc. Provide an `Array` of `String`s that,
+    # when matched in a hash key, will be censored and not sent to Sentry.
     #
     # See `Processor::SanitizeData::DEFAULT_FIELDS`.
     property sanitize_fields = [] of String | Regex
@@ -225,10 +226,13 @@ module Raven
     # Timeout when waiting for the server to return data.
     property read_timeout : Time::Span = 2.seconds
 
-    # Optional `Proc`, called when the Sentry server cannot be contacted for any reason.
+    # Optional `Proc`, called when the Sentry server cannot be contacted
+    # for any reason.
     #
     # ```
-    # ->(event : Raven::Event::HashType) { spawn { MyJobProcessor.send_email(event) } }
+    # ->(event : Raven::Event::HashType) {
+    #   spawn { MyJobProcessor.send_email(event) }
+    # }
     # ```
     property transport_failure_callback : Proc(Event::HashType, Nil)?
 
@@ -240,7 +244,7 @@ module Raven
       }
     end
 
-    # Errors object - an Array that contains error messages.
+    # Errors object - an `Array` containing error messages.
     getter errors = [] of String
 
     def initialize

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -311,8 +311,9 @@ module Raven
     end
 
     private def heroku_dyno_metadata_message
-      "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's" \
-      "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`"
+      "You are running on Heroku but haven't enabled Dyno Metadata. " \
+      "For Sentry's release detection to work correctly, please run " \
+      "`heroku labs:enable runtime-dyno-metadata`"
     end
 
     private def detect_release_from_heroku

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -5,7 +5,7 @@ module Raven
   class Configuration
     # Array of required properties needed to be set, before
     # `Configuration` is considered valid.
-    REQUIRED_OPTIONS = %i(host public_key secret_key project_id)
+    REQUIRED_OPTIONS = %i(host public_key project_id)
 
     # Array of exception classes that should never be sent.
     IGNORE_DEFAULT = [
@@ -191,7 +191,10 @@ module Raven
       property ssl : OpenSSL::SSL::Context::Client?
     {% end %}
 
-    # Secret key for authentication with the Sentry server
+    # Secret key for authentication with the Sentry server.
+    #
+    # DEPRECATED: This is deprecated and not necessary for newer Sentry
+    # installations any more.
     #
     # NOTE: If you provide a DSN, this will be set automatically.
     property secret_key : String?

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -8,9 +8,7 @@ module Raven
     REQUIRED_OPTIONS = %i(host public_key project_id)
 
     # Array of exception classes that should never be sent.
-    IGNORE_DEFAULT = [
-      "Kemal::Exceptions::RouteNotFound",
-    ] of Exception.class | String
+    IGNORE_DEFAULT = [] of Exception.class | String
 
     # Note the order - we have to remove circular references and bad characters
     # before passing to other processors.

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -360,7 +360,9 @@ module Raven
 
     def capture_allowed?
       @errors = [] of String
-      valid? && capture_in_current_environment? && sample_allowed?
+      valid? &&
+        capture_in_current_environment? &&
+        sample_allowed?
     end
 
     def capture_allowed?(message_or_exc)

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -118,7 +118,7 @@ module Raven
     protected def self.format_culprit_name(frame)
       return unless frame
       parts = {
-        [nil, frame.filename],
+        [nil, frame.filename || frame.abs_path],
         ["in", frame.function],
         ["at line", frame.lineno],
       }

--- a/src/raven/integrations/amber.cr
+++ b/src/raven/integrations/amber.cr
@@ -24,4 +24,6 @@ module Raven
   end
 end
 
+Raven::Configuration::IGNORE_DEFAULT << Amber::Exceptions::RouteNotFound
+
 require "./amber/**"

--- a/src/raven/integrations/amber.cr
+++ b/src/raven/integrations/amber.cr
@@ -1,3 +1,5 @@
+require "amber"
+
 module Raven
   # ```
   # require "raven/integrations/amber"

--- a/src/raven/integrations/amber/pipes/user_feedback.cr
+++ b/src/raven/integrations/amber/pipes/user_feedback.cr
@@ -27,7 +27,7 @@ module Raven
         include Raven::UserFeedbackHandler
 
         protected def render_view(ex)
-          production? = ::Amber.env.production? # ameba:disable UselessAssign
+          production? = ::Amber.env.production? # ameba:disable Lint/UselessAssign
           {% begin %}
             render "user_feedback.ecr",
               path: "{{__DIR__.id}}/../../shared/views",

--- a/src/raven/integrations/kemal.cr
+++ b/src/raven/integrations/kemal.cr
@@ -24,4 +24,6 @@ module Raven
   end
 end
 
+Raven::Configuration::IGNORE_DEFAULT << Kemal::Exceptions::RouteNotFound
+
 require "./kemal/*"

--- a/src/raven/integrations/kemal/exception_handler.cr
+++ b/src/raven/integrations/kemal/exception_handler.cr
@@ -26,7 +26,7 @@ module Raven
       end
 
       def build_raven_culprit_context(context : HTTP::Server::Context)
-        context.route if context.route_defined?
+        context.route if context.route_found?
       end
 
       def build_raven_http_url(context : HTTP::Server::Context)

--- a/src/raven/integrations/kemal/log_handler.cr
+++ b/src/raven/integrations/kemal/log_handler.cr
@@ -23,7 +23,7 @@ module Raven
       def initialize(@wrapped = nil)
       end
 
-      def next=(handler : HTTP::Handler | Proc | Nil)
+      def next=(handler : HTTP::Handler | HTTP::Handler::HandlerProc | Nil)
         @wrapped.try(&.next=(handler)) || (@next = handler)
       end
 

--- a/src/raven/integrations/kemal/user_feedback_handler.cr
+++ b/src/raven/integrations/kemal/user_feedback_handler.cr
@@ -18,7 +18,7 @@ module Raven
       include Raven::UserFeedbackHandler
 
       protected def render_view(ex)
-        production? = ::Kemal.config.env == "production" # ameba:disable UselessAssign
+        production? = ::Kemal.config.env == "production" # ameba:disable Lint/UselessAssign
         {% begin %}
           render "{{__DIR__.id}}/../shared/views/user_feedback.ecr"
         {% end %}

--- a/src/raven/integrations/shared/views/user_feedback.ecr
+++ b/src/raven/integrations/shared/views/user_feedback.ecr
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-  <script src="https://cdn.ravenjs.com/3.25.2/raven.min.js"></script>
+  <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js"></script>
   <script>
     var showReportDialog = function() {
       Raven.showReportDialog({

--- a/src/raven/integrations/sidekiq/exception_handler.cr
+++ b/src/raven/integrations/sidekiq/exception_handler.cr
@@ -11,7 +11,7 @@ module Raven
     # cli.run(server)
     # ```
     class ExceptionHandler < ::Sidekiq::ExceptionHandler::Base
-      def call(ex : Exception, context : Hash(String, JSON::Type)? = nil)
+      def call(ex : Exception, context : Hash(String, JSON::Any)? = nil)
         Raven.capture(ex) do |event|
           event.logger ||= "sidekiq"
           event.extra.merge! context

--- a/src/raven/processors/utf8_conversion.cr
+++ b/src/raven/processors/utf8_conversion.cr
@@ -27,7 +27,7 @@ module Raven
       str = str.encode("UTF-16", invalid: :skip)
       str = String.new(str, "UTF-16")
       str = str.encode("UTF-8", invalid: :skip)
-      str = String.new(str, "UTF-8") # ameba:disable UselessAssign
+      str = String.new(str, "UTF-8") # ameba:disable Lint/UselessAssign
     end
   end
 end

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.0.0-rc3"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
### DONE:
- Bumped minimal required Crystal version to `0.26.0`
- Added support for public only DSNs
- Fixed _Kemal_ integration to make it work with Kemal v0.24.0 (thanks @mamantoha!)
- Fixed wrong type of `context` in _Sidekiq_ integration
- Fixed missing `require` in _Amber_ integration
- Use Classes instead of Strings for _404 Not Found_ Exceptions added to `Configuration::IGNORE_DEFAULT` in Amber/Kemal integrations
- Updated `crash_handler` with newest backtrace format
- Various small tweaks and improvements

It's good to go once https://github.com/amberframework/amber/pull/930 is merged. 