### PR TITLE
v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ end
 
 ### Raven doesn't report some kinds of data by default.
 
-Raven ignores some exceptions by default - most of these are related to 404s or
-controller actions not being found. [For a complete list, see the `IGNORE_DEFAULT` constant](https://github.com/Sija/raven.cr/blob/master/src/raven/configuration.cr).
+If used with integrations, Raven ignores some exceptions by default - most of
+these are related to 404s or controller actions not being found.
 
 Raven doesn't report `POST`, `PUT`, `PATCH` data or cookies by default.
 In addition, it will attempt to remove any obviously sensitive data,
@@ -101,8 +101,9 @@ Raven.configure do |config|
 end
 ```
 
-And, while not necessary if using `SENTRY_DSN`, you can also provide an `environments`
-setting. Raven will only capture events when `KEMAL_ENV` matches an environment in the list.
+And, while not necessary if using `SENTRY_DSN`, you can also provide an
+`environments` setting. Raven will only capture events when
+`SENTRY_CURRENT_ENV` or `KEMAL_ENV` matches an environment in the list.
 
 ```crystal
 Raven.configure do |config|

--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.26.0
+crystal: 0.27.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.0.0-rc3
+version: 1.0.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.0.0
+version: 1.1.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/spec/raven/event_spec.cr
+++ b/spec/raven/event_spec.cr
@@ -215,7 +215,7 @@ describe Raven::Event do
 
   context "merging exception context into extra hash" do
     exception = Exception.new
-    exception.__raven_context.merge!({
+    Raven.annotate_exception(exception, extra: {
       "context_event_key" => "context_value",
       "context_key"       => "context_value",
     })
@@ -376,7 +376,7 @@ describe Raven::Event do
       end
 
       it "adds an annotation to extra hash" do
-        Raven.annotate_exception(exception, foo: "bar")
+        Raven.annotate_exception(exception, extra: {foo: "bar"})
         Raven::Event.from(exception).extra.should eq({:foo => "bar"})
       end
 

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -172,7 +172,7 @@ module Raven
           in_fiber = match["in_fiber"]?
           fiber_name = match["fiber_name"]?
           backtrace = backtrace.gsub /^\s*from\s*/m, ""
-          capture_crystal_exception(klass, msg, backtrace, extra: {
+          capture_crystal_exception(klass, msg, backtrace, tags: {
             in_fiber:   !!in_fiber,
             fiber_name: fiber_name,
           })

--- a/src/raven/backtrace.cr
+++ b/src/raven/backtrace.cr
@@ -18,9 +18,7 @@ module Raven
         end
       end.compact
 
-      lines = filtered_lines.map do |unparsed_line|
-        Line.parse(unparsed_line)
-      end
+      lines = filtered_lines.map &->Line.parse(String)
       new(lines)
     end
 

--- a/src/raven/backtrace_line.cr
+++ b/src/raven/backtrace_line.cr
@@ -10,14 +10,14 @@ module Raven
       # - `lib/foo/src/foo/bar.cr:50:7 in '*Foo::Bar#_baz:Foo::Bam'`
       # - `lib/foo/src/foo/bar.cr:29:9 in '*Foo::Bar::bar_by_id<String>:Foo::Bam'`
       # - `/usr/local/Cellar/crystal-lang/0.24.1/src/fiber.cr:114:3 in '*Fiber#run:(IO::FileDescriptor | Nil)'`
-      CRYSTAL_METHOD: /^(?<file>[^:]+)(?:\:(?<line>\d+)(?:\:(?<col>\d+))?)? in '\*?(?<method>.*?)'( at #{ADDR_FORMAT})?$/,
+      CRYSTAL_METHOD: /^(?<file>[^:]+)(?:\:(?<line>\d+)(?:\:(?<col>\d+))?)? in '\*?(?<method>.*?)'(?: at #{ADDR_FORMAT})?$/,
 
       # Examples:
       #
       # - `~procProc(Nil)@/usr/local/Cellar/crystal-lang/0.24.1/src/http/server.cr:148 at 0x102cee376`
       # - `~procProc(HTTP::Server::Context, String)@lib/kemal/src/kemal/route.cr:11 at 0x102ce57db`
       # - `~procProc(HTTP::Server::Context, (File::PReader | HTTP::ChunkedContent | HTTP::Server::Response | HTTP::Server::Response::Output | HTTP::UnknownLengthContent | HTTP::WebSocket::Protocol::StreamIO | IO::ARGF | IO::Delimited | IO::FileDescriptor | IO::Hexdump | IO::Memory | IO::MultiWriter | IO::Sized | Int32 | OpenSSL::SSL::Socket | String::Builder | Zip::ChecksumReader | Zip::ChecksumWriter | Zlib::Deflate | Zlib::Inflate | Nil))@src/foo/bar/baz.cr:420`
-      CRYSTAL_PROC: /^(?<method>~[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+))( at #{ADDR_FORMAT})?$/,
+      CRYSTAL_PROC: /^(?<method>~[^@]+)@(?<file>[^:]+)(?:\:(?<line>\d+))(?: at #{ADDR_FORMAT})?$/,
 
       # Examples:
       #
@@ -75,16 +75,18 @@ module Raven
 
     # Reconstructs the line in a readable fashion
     def to_s(io)
-      io << '`' << method << '`' if method
-      if file
-        io << " at " << file
-        io << ':' << number if number
-        io << ':' << column if column
+      io << '`' << @method << '`' if @method
+      if @file
+        io << " at " << @file
+        io << ':' << @number if @number
+        io << ':' << @column if @column
       end
     end
 
     def inspect(io)
-      io << "Backtrace::Line(" << self << ')'
+      io << "Backtrace::Line("
+      to_s(io)
+      io << ')'
     end
 
     # FIXME: untangle it from global `Raven`.

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -71,7 +71,8 @@ module Raven
       }
     end
 
-    # `KEMAL_ENV` by default.
+    # Defaults to `SENTRY_CURRENT_ENV` or `KEMAL_ENV` `ENV` variables if set,
+    # `"default"` otherwise.
     property current_environment : String?
 
     # Encoding type for event bodies.
@@ -156,8 +157,8 @@ module Raven
     property? sanitize_credit_cards = true
 
     # By default, Sentry censors `Hash` values when their keys match things like
-    # `"secret"`, `"password"`, etc. Provide an `Array` of `String`s that, when matched in
-    # a hash key, will be censored and not sent to Sentry.
+    # `"secret"`, `"password"`, etc. Provide an `Array` of `String`s that,
+    # when matched in a hash key, will be censored and not sent to Sentry.
     #
     # See `Processor::SanitizeData::DEFAULT_FIELDS`.
     property sanitize_fields = [] of String | Regex
@@ -225,10 +226,13 @@ module Raven
     # Timeout when waiting for the server to return data.
     property read_timeout : Time::Span = 2.seconds
 
-    # Optional `Proc`, called when the Sentry server cannot be contacted for any reason.
+    # Optional `Proc`, called when the Sentry server cannot be contacted
+    # for any reason.
     #
     # ```
-    # ->(event : Raven::Event::HashType) { spawn { MyJobProcessor.send_email(event) } }
+    # ->(event : Raven::Event::HashType) {
+    #   spawn { MyJobProcessor.send_email(event) }
+    # }
     # ```
     property transport_failure_callback : Proc(Event::HashType, Nil)?
 
@@ -240,7 +244,7 @@ module Raven
       }
     end
 
-    # Errors object - an Array that contains error messages.
+    # Errors object - an `Array` containing error messages.
     getter errors = [] of String
 
     def initialize

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -360,7 +360,9 @@ module Raven
 
     def capture_allowed?
       @errors = [] of String
-      valid? && capture_in_current_environment? && sample_allowed?
+      valid? &&
+        capture_in_current_environment? &&
+        sample_allowed?
     end
 
     def capture_allowed?(message_or_exc)

--- a/src/raven/ext/exception.cr
+++ b/src/raven/ext/exception.cr
@@ -1,3 +1,5 @@
 class Exception
-  any_json_property :__raven_context
+  {% for key in %i(user tags extra) %}
+    any_json_property :__raven_{{ key.id }}
+  {% end %}
 end

--- a/src/raven/instance.cr
+++ b/src/raven/instance.cr
@@ -228,7 +228,11 @@ module Raven
     # end
     # ```
     def annotate_exception(exc, **options)
-      exc.__raven_context.merge!(options)
+      {% for key in %i(user tags extra) %}
+        if v = options[:{{ key.id }}]?
+          exc.__raven_{{ key.id }}.merge!(v)
+        end
+      {% end %}
       exc
     end
 

--- a/src/raven/integrations/amber.cr
+++ b/src/raven/integrations/amber.cr
@@ -2,6 +2,7 @@ require "amber"
 
 module Raven
   # ```
+  # require "raven"
   # require "raven/integrations/amber"
   # ```
   #

--- a/src/raven/integrations/kemal.cr
+++ b/src/raven/integrations/kemal.cr
@@ -2,6 +2,7 @@ require "kemal"
 
 module Raven
   # ```
+  # require "raven"
   # require "raven/integrations/kemal"
   # ```
   #

--- a/src/raven/integrations/kernel/spawn.cr
+++ b/src/raven/integrations/kernel/spawn.cr
@@ -1,0 +1,15 @@
+def spawn(*, name : String? = nil, &block)
+  # ameba:disable Style/RedundantBegin
+  wrapped_block = ->{
+    begin
+      block.call
+    rescue ex
+      Raven.capture(ex, extra: {
+        in_fiber:   true,
+        fiber_name: name,
+      })
+      raise ex
+    end
+  }
+  previous_def(name: name, &wrapped_block)
+end

--- a/src/raven/integrations/kernel/spawn.cr
+++ b/src/raven/integrations/kernel/spawn.cr
@@ -4,7 +4,7 @@ def spawn(*, name : String? = nil, &block)
     begin
       block.call
     rescue ex
-      Raven.capture(ex, extra: {
+      Raven.capture(ex, tags: {
         in_fiber:   true,
         fiber_name: name,
       })

--- a/src/raven/integrations/lucky/error_handler.cr
+++ b/src/raven/integrations/lucky/error_handler.cr
@@ -10,7 +10,7 @@ module Raven
     # server = HTTP::Server.new([
     #   # ...
     #   Lucky::ErrorHandler.new(action: Errors::Show),
-    #   Raven::Lucky::ErrorHandler,
+    #   Raven::Lucky::ErrorHandler.new,
     #   # ...
     # ])
     # ```

--- a/src/raven/integrations/sidekiq.cr
+++ b/src/raven/integrations/sidekiq.cr
@@ -2,6 +2,7 @@ require "sidekiq"
 
 module Raven
   # ```
+  # require "raven"
   # require "raven/integrations/sidekiq"
   # ```
   module Sidekiq

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.0.0-rc3"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
### DONE:
- `Raven.annotate_exception` accepts `:user`, `:tags` and `:extra` contexts, closes #7
- Added [Lucky](https://github.com/luckyframework/lucky) integration, closes #35
- Crash handler supports capturing multiple exceptions
- Crash handler supports capturing exceptions thrown within fibers (Crystal 0.27+)
- Added optional wrapper for `spawn` to capture exception thrown within fibers