### PR TITLE
epoch to to_unix for Crystal 0.27 compatibility

### DIFF
--- a/src/raven/breadcrumb.cr
+++ b/src/raven/breadcrumb.cr
@@ -64,7 +64,7 @@ module Raven
 
     def to_hash
       {
-        "timestamp" => @timestamp.to_utc.epoch,
+        "timestamp" => @timestamp.to_utc.to_unix,
         "type"      => @type.try(&.to_s.downcase),
         "message"   => @message,
         "data"      => data.to_h,


### PR DESCRIPTION
Updated epoch with to_unix for Crystal 0.27 compatibility