### PR TITLE
v1.5.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.5.0
+version: 1.5.1
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/spec/raven/client_state_spec.cr
+++ b/spec/raven/client_state_spec.cr
@@ -21,7 +21,7 @@ describe Raven::Client::State do
 
   it "should try again after time passes" do
     with_client_state do |state|
-      Timecop.freeze(Time.now - 10.seconds) { state.failure }
+      Timecop.freeze(Time.utc - 10.seconds) { state.failure }
       state.should_try?.should be_true
     end
   end
@@ -36,28 +36,28 @@ describe Raven::Client::State do
 
   it "should try again after retry_after" do
     with_client_state do |state|
-      Timecop.freeze(Time.now - 2.seconds) { state.failure(1.second) }
+      Timecop.freeze(Time.utc - 2.seconds) { state.failure(1.second) }
       state.should_try?.should be_true
     end
   end
 
   it "should exponentially backoff" do
     with_client_state do |state|
-      Timecop.freeze(Time.now) do
+      Timecop.freeze(Time.utc) do
         state.failure
-        Timecop.travel(Time.now + 2.seconds)
+        Timecop.travel(Time.utc + 2.seconds)
         state.should_try?.should be_true
 
         state.failure
-        Timecop.travel(Time.now + 3.seconds)
+        Timecop.travel(Time.utc + 3.seconds)
         state.should_try?.should be_false
-        Timecop.travel(Time.now + 2.seconds)
+        Timecop.travel(Time.utc + 2.seconds)
         state.should_try?.should be_true
 
         state.failure
-        Timecop.travel(Time.now + 8.seconds)
+        Timecop.travel(Time.utc + 8.seconds)
         state.should_try?.should be_false
-        Timecop.travel(Time.now + 2.seconds)
+        Timecop.travel(Time.utc + 2.seconds)
         state.should_try?.should be_true
       end
     end

--- a/spec/raven/event_spec.cr
+++ b/spec/raven/event_spec.cr
@@ -93,9 +93,9 @@ describe Raven::Event do
   end
 
   context "with user context specified" do
-    Raven.user_context({"id" => "hello"})
-
     it "adds user data" do
+      Raven.user_context({"id" => "hello"})
+
       with_event_hash(clear: false) do |hash|
         hash[:user].should eq({"id" => "hello"})
       end
@@ -103,9 +103,9 @@ describe Raven::Event do
   end
 
   context "with tags context specified" do
-    Raven.tags_context({"key" => "value"})
-
     it "merges tags data" do
+      Raven.tags_context({"key" => "value"})
+
       with_event_hash(tags: {"foo" => "bar"}, clear: false) do |hash|
         hash[:tags].should eq({"key" => "value", "foo" => "bar"})
       end
@@ -113,9 +113,9 @@ describe Raven::Event do
   end
 
   context "with extra context specified" do
-    Raven.extra_context({"key" => "value"})
-
     it "merges extra data" do
+      Raven.extra_context({"key" => "value"})
+
       with_event_hash(extra: {"foo" => "bar"}, clear: false) do |hash|
         hash[:extra].should eq({"key" => "value", "foo" => "bar"})
       end
@@ -123,12 +123,12 @@ describe Raven::Event do
   end
 
   context "with configuration tags specified" do
-    config = Raven::Configuration.new
-    config.tags = {"key" => "value"}
-    config.release = "custom"
-    config.current_environment = "custom"
-
     it "merges tags data" do
+      config = Raven::Configuration.new
+      config.tags = {"key" => "value"}
+      config.release = "custom"
+      config.current_environment = "custom"
+
       with_event_hash(tags: {"foo" => "bar"}, configuration: config) do |hash|
         hash[:tags].should eq({"key" => "value", "foo" => "bar"})
         hash[:release].should eq("custom")
@@ -138,9 +138,9 @@ describe Raven::Event do
   end
 
   context "with configuration tags unspecified" do
-    config = Raven::Configuration.new
-
     it "should not persist tags between unrelated events" do
+      config = Raven::Configuration.new
+
       with_event_hash(tags: {"foo" => "bar"}, configuration: config) do
         with_event_hash(configuration: config) do |hash2|
           hash2[:tags].should eq({} of String => String)
@@ -150,29 +150,29 @@ describe Raven::Event do
   end
 
   context "tags hierarchy respected" do
-    config = Raven::Configuration.new
-    config.tags = {
-      "configuration_context_event_key" => "configuration_value",
-      "configuration_context_key"       => "configuration_value",
-      "configuration_event_key"         => "configuration_value",
-      "configuration_key"               => "configuration_value",
-    }
-
-    Raven.tags_context({
-      "configuration_context_event_key" => "context_value",
-      "configuration_context_key"       => "context_value",
-      "context_event_key"               => "context_value",
-      "context_key"                     => "context_value",
-    })
-
-    event_tags = {
-      "configuration_context_event_key" => "event_value",
-      "configuration_event_key"         => "event_value",
-      "context_event_key"               => "event_value",
-      "event_key"                       => "event_value",
-    }
-
     it "merges tags data" do
+      config = Raven::Configuration.new
+      config.tags = {
+        "configuration_context_event_key" => "configuration_value",
+        "configuration_context_key"       => "configuration_value",
+        "configuration_event_key"         => "configuration_value",
+        "configuration_key"               => "configuration_value",
+      }
+
+      Raven.tags_context({
+        "configuration_context_event_key" => "context_value",
+        "configuration_context_key"       => "context_value",
+        "context_event_key"               => "context_value",
+        "context_key"                     => "context_value",
+      })
+
+      event_tags = {
+        "configuration_context_event_key" => "event_value",
+        "configuration_event_key"         => "event_value",
+        "context_event_key"               => "event_value",
+        "event_key"                       => "event_value",
+      }
+
       with_event_hash(tags: event_tags, configuration: config, clear: false) do |hash|
         hash[:tags].should eq({
           "configuration_context_event_key" => "event_value",
@@ -189,19 +189,19 @@ describe Raven::Event do
 
   {% for key in %i(user extra tags) %}
     context "with {{key.id}} context specified" do
-      Raven::Context.clear!
-
-      Raven.{{key.id}}_context({
-        "context_event_key" => "context_value",
-        "context_key"       => "context_value",
-      })
-
-      event_context = {
-        "context_event_key" => "event_value",
-        "event_key"         => "event_value",
-      }
-
       it "prioritizes event context" do
+        Raven::Context.clear!
+
+        Raven.{{key.id}}_context({
+          "context_event_key" => "context_value",
+          "context_key"       => "context_value",
+        })
+
+        event_context = {
+          "context_event_key" => "event_value",
+          "event_key"         => "event_value",
+        }
+
         with_event_hash({{key.id}}: event_context, clear: false) do |hash|
           hash[{{key}}].should eq({
             "context_event_key" => "event_value",
@@ -214,18 +214,18 @@ describe Raven::Event do
   {% end %}
 
   context "merging exception context into extra hash" do
-    exception = Exception.new
-    Raven.annotate_exception(exception, extra: {
-      "context_event_key" => "context_value",
-      "context_key"       => "context_value",
-    })
-    event_context = {
-      "context_event_key" => "event_value",
-      "event_key"         => "event_value",
-    }
-    hash = Raven::Event.from(exception, extra: event_context).to_hash
-
     it "prioritizes event context over request context" do
+      exception = Exception.new
+      Raven.annotate_exception(exception, extra: {
+        "context_event_key" => "context_value",
+        "context_key"       => "context_value",
+      })
+      event_context = {
+        "context_event_key" => "event_value",
+        "event_key"         => "event_value",
+      }
+      hash = Raven::Event.from(exception, extra: event_context).to_hash
+
       hash[:extra].should eq({
         "context_event_key" => "event_value",
         "context_key"       => "context_value",
@@ -345,28 +345,28 @@ describe Raven::Event do
       end
 
       context "for a nested exception type" do
-        exception = Raven::Test::Exception.new(message)
-        hash = Raven::Event.from(exception).to_hash
-
         it "sends the module name as part of the exception info" do
+          exception = Raven::Test::Exception.new(message)
+          hash = Raven::Event.from(exception).to_hash
+
           exception_value_from_event_hash(hash, 0)[:module].should eq("Raven::Test")
         end
       end
 
       context "when the exception has a cause" do
-        exception = build_exception_with_cause
-        hash = Raven::Event.from(exception).to_hash
-
         it "captures the cause" do
+          exception = build_exception_with_cause
+          hash = Raven::Event.from(exception).to_hash
+
           hash[:exception].as(Hash)[:values].as(Array).size.should eq(2)
         end
       end
 
       context "when the exception has nested causes" do
-        exception = build_exception_with_two_causes
-        hash = Raven::Event.from(exception).to_hash
-
         it "captures nested causes" do
+          exception = build_exception_with_two_causes
+          hash = Raven::Event.from(exception).to_hash
+
           hash[:exception].as(Hash)[:values].as(Array).size.should eq(3)
         end
       end

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -151,7 +151,7 @@ module Raven
 
     def run : Nil
       configure!
-      @started_at = Time.now
+      @started_at = Time.utc
 
       capture_with_options do
         start = Time.monotonic

--- a/src/raven/breadcrumb.cr
+++ b/src/raven/breadcrumb.cr
@@ -61,7 +61,7 @@ module Raven
     any_json_property :data
 
     def initialize(**options)
-      @timestamp = Time.now
+      @timestamp = Time.utc
       initialize_with **options
     end
 

--- a/src/raven/client.cr
+++ b/src/raven/client.cr
@@ -107,14 +107,14 @@ module Raven
     private def failed_send(ex, event)
       @state.failure
       if ex
-        logger.error "Unable to record event with remote Sentry server \
+        logger.warn "Unable to record event with remote Sentry server \
           (#{ex.class} - #{ex.message}): #{ex.backtrace[0..10].join('\n')}"
       else
-        logger.error "Not sending event due to previous failure(s)"
+        logger.warn "Not sending event due to previous failure(s)"
       end
 
       message = event[:message]? || "<no message value>"
-      logger.error "Failed to submit event: #{message}"
+      logger.warn "Failed to submit event: #{message}"
 
       configuration.transport_failure_callback.try &.call(event)
     end

--- a/src/raven/client.cr
+++ b/src/raven/client.cr
@@ -105,8 +105,8 @@ module Raven
     end
 
     private def failed_send(ex, event)
-      @state.failure
       if ex
+        @state.failure
         logger.warn "Unable to record event with remote Sentry server \
           (#{ex.class} - #{ex.message}): #{ex.backtrace[0..10].join('\n')}"
       else

--- a/src/raven/client_state.cr
+++ b/src/raven/client_state.cr
@@ -20,7 +20,7 @@ module Raven
 
       interval = @retry_after || ({@retry_number, 6}.min ** 2).seconds
       if timestamp = @last_check
-        return true if (Time.now - timestamp) >= interval
+        return true if (Time.utc - timestamp) >= interval
       else
         return true
       end
@@ -30,7 +30,7 @@ module Raven
     def failure(retry_after = nil) : Nil
       @status = Status::ERROR
       @retry_number += 1
-      @last_check = Time.now
+      @last_check = Time.utc
       @retry_after = retry_after
     end
 

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -164,7 +164,7 @@ module Raven
       @breadcrumbs = options[:breadcrumbs]? || Raven.breadcrumbs
       @context = options[:context]? || Raven.context
       @id = UUID.random.hexstring
-      @timestamp = Time.now
+      @timestamp = Time.utc
       @level = Severity::ERROR
       @server_name = @configuration.server_name
       @release = @configuration.release

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end


### PR DESCRIPTION
- Fixed specs to work with Crystal `0.31.0`
- Fixed deprecation warnings
- Only warn for `4xx` errors from Sentry
- Fixed infinite backoff under pressure 