### PR TITLE
v1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Raven.capture do
 end
 
 begin
-  1 / 0
+  1 // 0
 rescue ex : DivisionByZeroError
   Raven.capture(ex)
 end

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.5.1
+version: 1.5.2
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/spec/raven/client_spec.cr
+++ b/spec/raven/client_spec.cr
@@ -4,6 +4,10 @@ class ClientTest < Raven::Client
   def generate_auth_header
     super
   end
+
+  def get_message_from_exception(event)
+    super
+  end
 end
 
 def build_configuration
@@ -16,6 +20,15 @@ def with_client
 end
 
 describe Raven::Client do
+  context "#get_message_from_exception" do
+    it "returns exception class with message" do
+      event = Raven::Event.from(Exception.new("Foo!"))
+      with_client do |client|
+        client.get_message_from_exception(event.to_hash).should eq "Exception: Foo!"
+      end
+    end
+  end
+
   context "#generate_auth_header" do
     it "generates an auth header" do
       with_client do |client|

--- a/spec/raven/configuration_spec.cr
+++ b/spec/raven/configuration_spec.cr
@@ -46,6 +46,20 @@ def with_configuration_with_dsn
 end
 
 describe Raven::Configuration do
+  context "#valid?" do
+    it "returns true when DSN is set" do
+      with_configuration_with_dsn do |configuration|
+        configuration.valid?.should be_true
+      end
+    end
+
+    it "returns false when DSN is empty" do
+      with_configuration do |configuration|
+        configuration.valid?.should be_false
+      end
+    end
+  end
+
   it "should set #src_path to current dir from default" do
     with_configuration do |configuration|
       configuration.src_path.should eq(Dir.current)

--- a/spec/raven/configuration_spec.cr
+++ b/spec/raven/configuration_spec.cr
@@ -12,26 +12,6 @@ private class RandomSampleFail < Random::PCG32
   end
 end
 
-# Make sure we reset the env in case something leaks in
-def with_clean_env
-  sentry_vars = ->{ ENV.to_h.select { |key, _| key =~ /^SENTRY_/ } }
-  previous_vars = sentry_vars.call
-  begin
-    previous_vars.each do |key, _|
-      ENV.delete(key)
-    end
-    yield
-  ensure
-    extra_vars = sentry_vars.call
-    extra_vars.each do |key, _|
-      ENV.delete(key)
-    end
-    previous_vars.each do |key, value|
-      ENV[key] = value
-    end
-  end
-end
-
 def with_configuration
   with_clean_env do
     yield Raven::Configuration.new

--- a/spec/raven/event_spec.cr
+++ b/spec/raven/event_spec.cr
@@ -324,10 +324,6 @@ describe Raven::Event do
         Raven::Event.from(exception).should be_a(Raven::Event)
       end
 
-      it "sets the message to the exception's message and type" do
-        hash[:message].should eq("Exception: #{message}")
-      end
-
       it "has level ERROR" do
         hash[:level].should eq("error")
       end

--- a/spec/raven/instance_spec.cr
+++ b/spec/raven/instance_spec.cr
@@ -88,7 +88,6 @@ describe Raven::Instance do
       it "sends the result of Event.from" do
         with_instance do |instance|
           instance.capture(build_exception, id: "foo", logger: "bar")
-          instance.last_sent_event.try(&.message).should eq("Exception: Raven.cr test exception")
           instance.last_sent_event.try(&.id).should eq("foo")
           instance.last_sent_event.try(&.logger).should eq("bar")
         end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,26 @@
 require "spec"
 require "../src/raven"
 
+# Make sure we reset the env in case something leaks in
+def with_clean_env
+  sentry_vars = ->{ ENV.to_h.select { |key, _| key.starts_with?("SENTRY_") } }
+  previous_vars = sentry_vars.call
+  begin
+    previous_vars.each_key do |key|
+      ENV.delete(key)
+    end
+    yield
+  ensure
+    extra_vars = sentry_vars.call
+    extra_vars.each_key do |key|
+      ENV.delete(key)
+    end
+    previous_vars.each do |key, value|
+      ENV[key] = value
+    end
+  end
+end
+
 def build_exception
   Exception.new "Raven.cr test exception"
 end

--- a/src/raven/client.cr
+++ b/src/raven/client.cr
@@ -35,10 +35,18 @@ module Raven
     end
 
     def send_feedback(event_id : String, data : Hash)
+      unless configuration.valid?
+        logger.debug "Client#send_feedback with event id '#{event_id}' failed: #{configuration.error_messages}"
+        return false
+      end
       transport.send_feedback(event_id, data)
     end
 
     def send_event(event : Event | Event::HashType, hint : Event::Hint? = nil)
+      unless configuration.valid?
+        logger.debug "Client#send_event with event '#{event}' failed: #{configuration.error_messages}"
+        return false
+      end
       if event.is_a?(Event)
         configuration.before_send.try do |before_send|
           event = before_send.call(event, hint)

--- a/src/raven/client_state.cr
+++ b/src/raven/client_state.cr
@@ -19,11 +19,8 @@ module Raven
       return true if @status.online?
 
       interval = @retry_after || ({@retry_number, 6}.min ** 2).seconds
-      if timestamp = @last_check
-        return true if (Time.utc - timestamp) >= interval
-      else
-        return true
-      end
+      return true unless last_check = @last_check
+      return true if (Time.utc - last_check) >= interval
       false
     end
 

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -447,7 +447,7 @@ module Raven
       true
     end
 
-    private def valid?
+    def valid?
       valid = true
       if dsn
         {% for key in REQUIRED_OPTIONS %}

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -101,9 +101,6 @@ module Raven
       {% end %}
 
       new(**options).tap do |event|
-        # Messages limited to 10kb
-        event.message = "#{exc.class}: #{exc.message}".byte_slice(0, MAX_MESSAGE_SIZE_IN_BYTES)
-
         exc.callstack ||= CallStack.new
         add_exception_interface(event, exc)
       end

--- a/src/raven/event.cr
+++ b/src/raven/event.cr
@@ -107,9 +107,6 @@ module Raven
     end
 
     def self.from(message : String, **options)
-      # Messages limited to 10kb
-      message = message.byte_slice(0, MAX_MESSAGE_SIZE_IN_BYTES)
-
       new(**options).tap do |event|
         event.message = {message, options[:message_params]?}
       end
@@ -206,15 +203,24 @@ module Raven
     end
 
     def message=(message : String)
-      interface :message, message: message
+      interface :message, message: trim_message(message)
     end
 
-    def message=(message_with_params)
+    def message=(message_with_params : Enumerable | Indexable)
+      message, params = message_with_params
       options = {
-        message: message_with_params.first,
-        params:  message_with_params.last,
+        message: trim_message(message),
+        params:  params,
       }
       interface :message, **options
+    end
+
+    private def trim_message(message, ellipsis = " [...]")
+      if message.size > MAX_MESSAGE_SIZE_IN_BYTES
+        message = message.byte_slice(0, MAX_MESSAGE_SIZE_IN_BYTES - ellipsis.bytesize)
+        message += ellipsis
+      end
+      message
     end
 
     def backtrace=(backtrace)

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end


### PR DESCRIPTION
- `Raven::Client#send_{event,feedback}` methods will silently bail out for invalid connections (like no DSN set), closes #54 
- Removed redundant `#{exception.class.name}: ` prefix within the logged message
- Messages are now trimmed with ellipsis suffix string added (`[...]`)