### PR TITLE
v1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Raven supports two methods of capturing exceptions:
 ```crystal
 Raven.capture do
   # capture any exceptions which happen during execution of this block
-  1 / 0
+  1 // 0
 end
 
 begin

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.5.2
+version: 1.5.3
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.5.2"
+  VERSION = "1.5.3"
 end


### PR DESCRIPTION
- Don't capture output in `crash_handler` to avoid memory bloat
- Fixed README examples