### PR TITLE
v1.6

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,7 +12,7 @@ dependencies:
 development_dependencies:
   timecop:
     github: crystal-community/timecop.cr
-    version: ~> 0.3.0
+    version: ~> 0.4.0
   ameba:
     github: crystal-ameba/ameba
     version: ~> 0.11.0

--- a/shard.yml
+++ b/shard.yml
@@ -21,6 +21,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.30.0
+crystal: 0.32.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.5.5
+version: 1.6.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/spec/raven/context_spec.cr
+++ b/spec/raven/context_spec.cr
@@ -1,0 +1,38 @@
+require "../spec_helper"
+
+describe Raven::Context do
+  {% for key in %i(user extra tags) %}
+    {% env_key = "SENTRY_CONTEXT_#{key.upcase.id}" %}
+
+    context %(with ENV["{{ env_key.id }}"]?) do
+      it "initializes from valid JSON-encoded string" do
+        with_clean_env do
+          ENV[{{ env_key }}] = {foo: :bar}.to_json
+
+          context = Raven::Context.new
+          context.{{ key.id }}.should eq({"foo" => "bar"})
+        end
+      end
+
+      it "raises when JSON-encoded string is not a Hash" do
+        with_clean_env do
+          ENV[{{ env_key }}] = (0..3).to_a.to_json
+
+          expect_raises(Raven::Error, {{ env_key }}) do
+            Raven::Context.new
+          end
+        end
+      end
+
+      it "raises on invalid JSON-encoded string" do
+        with_clean_env do
+          ENV[{{ env_key }}] = "foo"
+
+          expect_raises(Raven::Error, {{ env_key }}) do
+            Raven::Context.new
+          end
+        end
+      end
+    end
+  {% end %}
+end

--- a/spec/raven/instance_spec.cr
+++ b/spec/raven/instance_spec.cr
@@ -85,6 +85,24 @@ describe Raven::Instance do
             end
           end
         end
+
+        it "use passed values only within the block" do
+          with_instance do |instance|
+            Raven::Context.clear!
+            Raven.{{key.id}}_context(will: :stay_there)
+            ctx = Raven.{{key.id}}_context(foo: :foo, bar: :bar) do
+              instance.capture("Test message", {{key.id}}: {bar: "baz"}) do |event|
+                event.{{key.id}}.should eq({
+                  :will => :stay_there,
+                  :foo => :foo,
+                  :bar => "baz"
+                })
+              end
+            end
+            ctx.should eq({:will => :stay_there})
+            Raven.{{key.id}}_context.should be(ctx)
+          end
+        end
       end
     {% end %}
 

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -53,11 +53,7 @@ module Raven
     property logger : ::Logger {
       Logger.new({{ "STDOUT".id unless flag?(:release) }}).tap do |logger|
         logger.level = {{ flag?(:debug) ? "Logger::DEBUG".id : "Logger::ERROR".id }}
-
-        "#{logger.progname}.crash_handler".tap do |progname|
-          logger.progname = progname
-          configuration.exclude_loggers << progname
-        end
+        logger.progname = "raven.crash_handler"
       end
     }
 

--- a/src/crash_handler.cr
+++ b/src/crash_handler.cr
@@ -141,8 +141,8 @@ module Raven
     private def run_process(error : IO = IO::Memory.new)
       @process_status = Process.run command: name, args: args,
         shell: true,
-        input: STDIN,
-        output: STDOUT,
+        input: Process::Redirect::Inherit,
+        output: Process::Redirect::Inherit,
         error: IO::MultiWriter.new(STDERR, error)
       error.to_s.chomp
     end

--- a/src/raven/instance.cr
+++ b/src/raven/instance.cr
@@ -285,6 +285,23 @@ module Raven
       context.extra.merge!(hash, options)
     end
 
+    {% for key in %i(user extra tags) %}
+      # Bind {{ key.id }} context.
+      # Merges with existing context (if any).
+      #
+      # See `#{{ key.id }}_context`
+      def {{ key.id }}_context(hash = nil, **options)
+        prev_context = context.{{ key.id }}.clone
+        begin
+          context.{{ key.id }}.merge!(hash, options)
+          yield
+        ensure
+          context.{{ key.id }} = prev_context
+        end
+        context.{{ key.id }}
+      end
+    {% end %}
+
     def breadcrumbs
       BreadcrumbBuffer.current
     end

--- a/src/raven/version.cr
+++ b/src/raven/version.cr
@@ -1,3 +1,3 @@
 module Raven
-  VERSION = "1.5.5"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
- Crystal 0.33.0 compatible
- Invoking `Instance#{user,extra,tags}_context` with a block, will set passed context within the executed block body (⚠️ non-MT friendly)
- Initialize `Context` from JSON-encoded ENV variables (`SENTRY_CONTEXT_{USER,EXTRA,TAGS}`) - fixes #62
- Several small tweaks