### PR TITLE
Log backend

### DIFF
--- a/src/raven/integrations/kernel/log.cr
+++ b/src/raven/integrations/kernel/log.cr
@@ -1,0 +1,44 @@
+require "log"
+require "../shared/breadcrumb_log_helper"
+
+module Raven
+  # ```
+  # require "raven"
+  # require "raven/integrations/kernel/log"
+  # ```
+  #
+  # `::Log::Backend` recording logged messages as breadcrumbs.
+  #
+  # ```
+  # Log.setup do |c|
+  #   c.bind "*", :info, Log::IOBackend.new
+  #   c.bind "*", :info, Raven::BreadcrumbLogBackend.new
+  # end
+  # ```
+  class BreadcrumbLogBackend < ::Log::Backend
+    include Raven::BreadcrumbLogHelper
+
+    private BREADCRUMB_LEVELS = {
+      :trace  => :debug,
+      :debug  => :debug,
+      :info   => :info,
+      :notice => :info,
+      :warn   => :warning,
+      :error  => :error,
+      :fatal  => :critical,
+    } of ::Log::Severity => Raven::Breadcrumb::Severity
+
+    def write(entry : ::Log::Entry)
+      message = entry.message
+      if ex = entry.exception
+        message += " -- (#{ex.class}): #{ex.message || "n/a"}"
+      end
+      record_breadcrumb(
+        BREADCRUMB_LEVELS[entry.severity]?,
+        entry.timestamp,
+        entry.source,
+        message,
+      )
+    end
+  end
+end

--- a/src/raven/integrations/kernel/logger.cr
+++ b/src/raven/integrations/kernel/logger.cr
@@ -1,47 +1,23 @@
 require "logger"
-
-module Raven::Breadcrumb::Logger
-  private LOGGER_BREADCRUMB_LEVELS = {
-    ::Logger::DEBUG => Severity::DEBUG,
-    ::Logger::INFO  => Severity::INFO,
-    ::Logger::WARN  => Severity::WARNING,
-    ::Logger::ERROR => Severity::ERROR,
-    ::Logger::FATAL => Severity::CRITICAL,
-  }
-
-  protected def self.ignored_logger?(progname)
-    Raven.configuration.exclude_loggers.includes?(progname)
-  end
-
-  protected def record_breadcrumb(severity, datetime, progname, message)
-    return if Logger.ignored_logger?(progname)
-    Raven.breadcrumbs.record do |crumb|
-      crumb.timestamp = datetime
-      crumb.level = LOGGER_BREADCRUMB_LEVELS[severity]?
-      crumb.category = progname || "logger"
-      crumb.message = message
-    end
-  end
-end
+require "../shared/breadcrumb_log_helper"
 
 class Logger
-  include Raven::Breadcrumb::Logger
+  include Raven::BreadcrumbLogHelper
 
-  protected def self.deansify(message)
-    case message
-    when Nil       then nil
-    when String    then message.gsub(/\x1b[^m]*m/, "")
-    when Exception then deansify(message.message)
-    else                deansify(message.to_s)
-    end
-  end
+  private BREADCRUMB_LEVELS = {
+    :debug => :debug,
+    :info  => :info,
+    :warn  => :warning,
+    :error => :error,
+    :fatal => :critical,
+  } of ::Logger::Severity => Raven::Breadcrumb::Severity
 
   private def write(severity, datetime, progname, message)
     record_breadcrumb(
-      severity,
+      BREADCRUMB_LEVELS[severity]?,
       datetime,
-      self.class.deansify(progname),
-      self.class.deansify(message),
+      progname,
+      message,
     )
     previous_def
   end

--- a/src/raven/integrations/shared/breadcrumb_log_helper.cr
+++ b/src/raven/integrations/shared/breadcrumb_log_helper.cr
@@ -1,0 +1,22 @@
+module Raven
+  module BreadcrumbLogHelper
+    protected def deansify(message) : String?
+      case message
+      when Nil       then nil
+      when String    then message.gsub(/\x1b[^m]*m/, "")
+      when Exception then deansify(message.message)
+      else                deansify(message.to_s)
+      end
+    end
+
+    protected def record_breadcrumb(level, timestamp, category, message) : Breadcrumb?
+      return if Raven.configuration.ignored_logger?(category)
+      Raven.breadcrumbs.record do |crumb|
+        crumb.level = level
+        crumb.timestamp = timestamp
+        crumb.category = category.presence || "logger"
+        crumb.message = deansify(message).presence
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added `Raven::BreadcrumbLogBackend` which can be used alongside other `Log` backends
- Changed `Raven::Configuration#exclude_loggers` to accept log source patterns rather then exact logger names, so `db.*` matches `db`, `db.query` and so on - works for both `Log` and `Logger`
- Refactored `Logger` integration 

Closes #67