### PR TITLE
v1.7.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -21,6 +21,6 @@ targets:
   crash_handler:
     main: src/crash_handler.cr
 
-crystal: 0.35.0
+crystal: ~> 0.35
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: raven
-version: 1.7.0
+version: 1.7.1
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/src/raven.cr
+++ b/src/raven.cr
@@ -22,11 +22,11 @@ module Raven
 
   macro sys_command_compiled(command)
     %result = {{ `(#{command.id} || true) 2>/dev/null`.stringify.strip }}
-    %result unless %result.empty?
+    %result.presence
   end
 
   def self.sys_command(command)
     result = `(#{command}) 2>/dev/null`.strip rescue nil
-    result if !result.nil? && !result.empty? && $?.success?
+    result.presence if $?.success?
   end
 end

--- a/src/raven/configuration.cr
+++ b/src/raven/configuration.cr
@@ -323,19 +323,10 @@ module Raven
       File.directory?("/etc/heroku")
     end
 
-    private HEROKU_DYNO_METADATA_MESSAGE =
-      "You are running on Heroku but haven't enabled Dyno Metadata. " \
-      "For Sentry's release detection to work correctly, please run " \
-      "`heroku labs:enable runtime-dyno-metadata`"
-
     private def detect_release_from_heroku
       return unless running_on_heroku?
       return if ENV["CI"]?
-      if commit = ENV["HEROKU_SLUG_COMMIT"]?
-        return commit
-      end
-      Log.warn { HEROKU_DYNO_METADATA_MESSAGE }
-      nil
+      ENV["HEROKU_SLUG_COMMIT"]?
     end
 
     private def detect_release_from_capistrano


### PR DESCRIPTION
- Fixed an initalzation loop when `BreadcrumbLogBackend` is being used with catch all source (`"*"`).
- Relaxed [`crystal`](https://github.com/crystal-lang/shards/blob/master/SPEC.md#crystal) version requirement (effectively to `< 1.0`)