### PR TITLE
Add serialization ignores to custom properties within the Exception class

### DIFF
--- a/src/raven/ext/exception.cr
+++ b/src/raven/ext/exception.cr
@@ -1,7 +1,11 @@
 class Exception
+  @[JSON::Field(ignore: true)]
+  @[YAML::Field(ignore: true)]
   property __raven_event_id : String?
 
   {% for key in %i(user tags extra) %}
+    @[JSON::Field(ignore: true)]
+    @[YAML::Field(ignore: true)]
     any_json_property :__raven_{{ key.id }}
   {% end %}
 end

--- a/src/raven/ext/exception.cr
+++ b/src/raven/ext/exception.cr
@@ -1,3 +1,6 @@
+require "json"
+require "yaml"
+
 class Exception
   @[JSON::Field(ignore: true)]
   @[YAML::Field(ignore: true)]


### PR DESCRIPTION
Closes #82, which can be viewed for more detail.

I've tested this by running the LuckyCasts repo against this patch branch without the workaround code in place, and the application successfully compiles on my branch and errors out against the master branch.