### PR TITLE
Add Marten integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,41 @@ As one would expect, `STDIN` is passed to the original process, while
 __NOTE__: You can always pass `SENTRY_DSN` env variable during execution
 in case you didn't do it while building the wrapper.
 
+## Integrations
+
+### Marten
+
+Raven.cr provides an integration that allows you to get automatic error reporting for the [Marten web framework](https://github.com/martenframework/marten) by using a dedicated [middleware](https://martenframework.com/docs/handlers-and-http/middlewares).
+
+To get started, make sure that Raven.cr is [properly required and configured](#usage). You should also ensure that `raven/integrations/marten` is required by your project. In a Marten project, you'll likely create a `config/initializers/raven.cr` initializer where you require and configure the Raven client for your project. For example:
+
+```crystal
+# config/initializers/raven.cr
+
+require "raven"
+require "raven/integrations/marten"
+
+Raven.configure do |config|
+  config.dsn = "your_dsn"
+end
+```
+
+To get automatic error reporting for your project, you need to add the `Raven::Marten::Middleware` middleware class to the [`middleware`](https://martenframework.com/docs/development/reference/settings#middleware) Marten setting. Ideally, this middleware should be placed near the beginning of the `middleware` array to ensure that it can catch any errors raised by the following middlewares in the stack. For example:
+
+```crystal
+# config/settings/base.cr
+
+Marten.configure do |config|
+  config.middleware = [
+    Raven::Marten::Middleware,
+    # Other middlewares...
+    Marten::Middleware::GZip,
+    Marten::Middleware::XFrameOptions,
+    Marten::Middleware::StrictTransportSecurity,
+  ]
+end
+```
+
 ## More Information
 
 - [Documentation](https://docs.sentry.io/clients/ruby)

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,9 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     version: ~> 1.4.0
+  marten:
+    github: martenframework/marten
+    version: ~> 0.2.0
 
 targets:
   crash_handler:

--- a/spec/ext/raven/instance.cr
+++ b/spec/ext/raven/instance.cr
@@ -1,0 +1,7 @@
+class Raven::Instance
+  getter last_sent_event : Raven::Event?
+
+  def send_event(event, hint = nil)
+    @last_sent_event = event
+  end
+end

--- a/spec/raven/integrations/marten/middleware_spec.cr
+++ b/spec/raven/integrations/marten/middleware_spec.cr
@@ -1,0 +1,273 @@
+require "marten"
+require "marten/spec"
+
+require "../../../../src/raven/integrations/marten"
+
+require "./spec_helper"
+
+private def with_clean_configuration(&)
+  prev_configuration = Raven.instance.configuration.dup
+  begin
+    Raven.instance.configuration = build_configuration
+    yield
+  ensure
+    Raven.instance.configuration = prev_configuration
+  end
+end
+
+describe Raven::Marten::Middleware do
+  around_each do |t|
+    original_allowed_hosts = Marten.settings.allowed_hosts
+
+    Marten.settings.allowed_hosts = %w(example.com www.example.com)
+
+    with_clean_configuration { t.run }
+
+    Marten.settings.allowed_hosts = original_allowed_hosts
+  end
+
+  describe "#call" do
+    it "returns the response as expected if no error occurs" do
+      middleware = Raven::Marten::Middleware.new
+
+      response = middleware.call(
+        Marten::HTTP::Request.new(
+          method: "GET",
+          resource: "/foo/bar",
+          headers: HTTP::Headers{"Host" => "example.com"}
+        ),
+        ->{ Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200) }
+      )
+
+      response.should be_a Marten::HTTP::Response
+      response.content.should eq "It works!"
+    end
+
+    it "properly sets the event culprit when capturing an exception" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "GET",
+            resource: "/foo/bar",
+            headers: HTTP::Headers{"Host" => "example.com"}
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      event.try(&.culprit).should eq "GET /foo/bar"
+    end
+
+    it "properly sets the event logger when capturing an exception" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "GET",
+            resource: "/foo/bar",
+            headers: HTTP::Headers{"Host" => "example.com"}
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      event.try(&.logger).should eq "marten"
+    end
+
+    it "properly sets the HTTP interface when capturing an exception for a GET request" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "GET",
+            resource: "/foo/bar?foo=bar&xyz=test",
+            headers: HTTP::Headers{"Host" => "example.com"}
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      http_interface = event.try { |e| e.interface(:http).as(Raven::Interface::HTTP) }
+
+      http_interface.try(&.method).should eq "GET"
+      http_interface.try(&.url).should eq "http://example.com/foo/bar?foo=bar&xyz=test"
+      http_interface.try(&.headers).should eq({"Host" => ["example.com"]})
+      http_interface.try(&.query_string).should eq "foo=bar&xyz=test"
+      http_interface.try(&.data.should(be_empty))
+    end
+
+    it "properly sets the HTTP interface when capturing an exception for a POST request" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "POST",
+            resource: "/foo/bar?param=val",
+            headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/x-www-form-urlencoded"},
+            body: "foo=bar&test=xyz&foo=baz"
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      http_interface = event.try { |e| e.interface(:http).as(Raven::Interface::HTTP) }
+
+      http_interface.try(&.method).should eq "POST"
+      http_interface.try(&.url).should eq "http://example.com/foo/bar?param=val"
+      http_interface.try(&.headers).should eq(
+        {"Host" => ["example.com"], "Content-Type" => ["application/x-www-form-urlencoded"], "Content-Length" => ["24"]}
+      )
+      http_interface.try(&.query_string).should eq "param=val"
+      http_interface.try(&.data).should eq({"foo" => ["bar", "baz"], "test" => ["xyz"]})
+    end
+
+    it "properly sets the HTTP interface when capturing an exception for a PUT request" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "PUT",
+            resource: "/foo/bar?param=val",
+            headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/x-www-form-urlencoded"},
+            body: "foo=bar&test=xyz&foo=baz"
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      http_interface = event.try { |e| e.interface(:http).as(Raven::Interface::HTTP) }
+
+      http_interface.try(&.method).should eq "PUT"
+      http_interface.try(&.url).should eq "http://example.com/foo/bar?param=val"
+      http_interface.try(&.headers).should eq(
+        {"Host" => ["example.com"], "Content-Type" => ["application/x-www-form-urlencoded"], "Content-Length" => ["24"]}
+      )
+      http_interface.try(&.query_string).should eq "param=val"
+      http_interface.try(&.data).should eq({"foo" => ["bar", "baz"], "test" => ["xyz"]})
+    end
+
+    it "properly sets the HTTP interface when capturing an exception for a PATCH request" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "PATCH",
+            resource: "/foo/bar?param=val",
+            headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/x-www-form-urlencoded"},
+            body: "foo=bar&test=xyz&foo=baz"
+          ),
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      http_interface = event.try { |e| e.interface(:http).as(Raven::Interface::HTTP) }
+
+      http_interface.try(&.method).should eq "PATCH"
+      http_interface.try(&.url).should eq "http://example.com/foo/bar?param=val"
+      http_interface.try(&.headers).should eq(
+        {"Host" => ["example.com"], "Content-Type" => ["application/x-www-form-urlencoded"], "Content-Length" => ["24"]}
+      )
+      http_interface.try(&.query_string).should eq "param=val"
+      http_interface.try(&.data).should eq({"foo" => ["bar", "baz"], "test" => ["xyz"]})
+    end
+
+    it "properly sets the cookies in the HTTP interface" do
+      request = Marten::HTTP::Request.new(
+        method: "GET",
+        resource: "/foo/bar",
+        headers: HTTP::Headers{"Host" => "example.com"}
+      )
+      request.cookies["test"] = "value"
+
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(DivisionByZeroError) do
+        middleware.call(
+          request,
+          ->{
+            1 // 0
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+      end
+
+      event = Raven.instance.last_sent_event
+      http_interface = event.try { |e| e.interface(:http).as(Raven::Interface::HTTP) }
+
+      http_interface.try(&.cookies).should eq "test=value"
+    end
+
+    it "does not capture HTTP not found exceptions" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(Marten::HTTP::Errors::NotFound) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "PUT",
+            resource: "/foo/bar?param=val",
+            headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/x-www-form-urlencoded"},
+            body: "foo=bar&test=xyz&foo=baz"
+          ),
+          ->{
+            raise Marten::HTTP::Errors::NotFound.new("This is bad")
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+
+        Raven.instance.last_sent_event.should be_nil
+      end
+    end
+
+    it "does not capture route not found exceptions" do
+      middleware = Raven::Marten::Middleware.new
+
+      expect_raises(Marten::Routing::Errors::NoResolveMatch) do
+        middleware.call(
+          Marten::HTTP::Request.new(
+            method: "PUT",
+            resource: "/foo/bar?param=val",
+            headers: HTTP::Headers{"Host" => "example.com", "Content-Type" => "application/x-www-form-urlencoded"},
+            body: "foo=bar&test=xyz&foo=baz"
+          ),
+          ->{
+            raise Marten::Routing::Errors::NoResolveMatch.new("This is bad")
+            Marten::HTTP::Response.new("It works!", content_type: "text/plain", status: 200)
+          }
+        )
+
+        Raven.instance.last_sent_event.should be_nil
+      end
+    end
+  end
+end

--- a/spec/raven/integrations/marten/spec_helper.cr
+++ b/spec/raven/integrations/marten/spec_helper.cr
@@ -1,0 +1,1 @@
+require "../../../spec_helper"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "log/spec"
 require "../src/raven"
+require "./ext/**"
 
 # Make sure we reset the env in case something leaks in
 def with_clean_env(&)

--- a/src/raven/integrations/marten.cr
+++ b/src/raven/integrations/marten.cr
@@ -1,0 +1,2 @@
+require "marten"
+require "./marten/**"

--- a/src/raven/integrations/marten/middleware.cr
+++ b/src/raven/integrations/marten/middleware.cr
@@ -1,0 +1,77 @@
+module Raven
+  module Marten
+    # Sentry middleware for Marten.
+    #
+    # In order to be used, this middleware should be added to the `middleware` Marten setting (ideally at the beginning
+    # of the middleware array):
+    #
+    # ```
+    # Marten.configure do |config|
+    #   config.middleware = [
+    #     Raven::Marten::Middleware,
+    #     Marten::Middleware::GZip,
+    #     Marten::Middleware::XFrameOptions,
+    #     Marten::Middleware::StrictTransportSecurity,
+    #   ]
+    # end
+    # ```
+    class Middleware < ::Marten::Middleware
+      def call(request : ::Marten::HTTP::Request, get_response : Proc(::Marten::HTTP::Response)) : ::Marten::HTTP::Response
+        get_response.call
+      rescue error
+        unless error.is_a?(::Marten::HTTP::Errors::NotFound | ::Marten::Routing::Errors::NoResolveMatch)
+          capture(request, error)
+        end
+
+        raise error
+      end
+
+      private CAPTURE_DATA_FOR_METHODS = %w(POST PUT PATCH)
+
+      private def build_full_url(request)
+        String.build do |url|
+          url << request.scheme
+          url << "://"
+          url << request.host
+          url << ":#{request.port}" if !["80", "443"].includes?(request.port)
+          url << request.full_path
+        end
+      end
+
+      private def capture(request, error)
+        Raven.capture(error) do |event|
+          data = if CAPTURE_DATA_FOR_METHODS.includes?(request.method)
+                   prepare_data(request.data)
+                 else
+                   nil
+                 end
+
+          event.culprit = "#{request.method} #{request.path}"
+          event.logger ||= "marten"
+          event.interface :http, {
+            headers:      request.headers.to_h,
+            cookies:      prepare_cookies(request.cookies),
+            method:       request.method,
+            url:          build_full_url(request),
+            query_string: request.query_params.as_query,
+            data:         data,
+          }
+        end
+      end
+
+      private def prepare_cookies(cookies)
+        cookies.to_stdlib.to_h.join("; ") { |_, cookie| cookie.to_cookie_header }
+      end
+
+      private def prepare_data(data)
+        prepared_data = {} of String => Array(String)
+
+        data.each do |k, v|
+          prepared_data[k] = v.map(&.to_s)
+        end
+
+        prepared_data
+      end
+    end
+  end
+end


### PR DESCRIPTION
First of all, thanks for this great shard!

This Pull Request adds an integration for the [Marten web framework](https://github.com/martenframework/marten).

I have been using raven.cr from quite some time for the [Marten website](https://github.com/martenframework/website), and I thought it would be nice to ensure that the middleware I created to have automatic error reporting is provided by this shard directly as an integration (like this is the case already for HTTP handlers and other frameworks). This will make it easier for people to use Sentry as part of Marten apps.

Unlike other integrations, Marten relies on a [middleware mechanism](https://martenframework.com/docs/handlers-and-http/middlewares) to "hook" into the  request/response lifecycle (and HTTP handlers are not exposed to developers using the framework). As such, this pull request does not reuse the existing logic provided by `Raven::HTTPHandler`.

It should be noted that I also added specs for the integration, which led me to add `martenframework/marten` to the development dependencies. Let me know if this isn't the right approach for testing integrations in this shard!